### PR TITLE
Test/110 check if the endpoint is working

### DIFF
--- a/apps/backend/src/api/routes/upload.py
+++ b/apps/backend/src/api/routes/upload.py
@@ -7,6 +7,7 @@ from src.services.upload_service import (
     generate_load_id,
     register_upload_start,
     run_etl_placeholder,
+    get_load_history
 )
 
 logger = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ async def upload_files(
     gbd: UploadFile | None = File(default=None),
     indicadores_continuidade: UploadFile | None = File(default=None),
     indicadores_continuidade_limite: UploadFile | None = File(default=None),
-):
+    ):
     files = {
         "energy_losses": energy_losses,
         "gbd": gbd,
@@ -49,3 +50,18 @@ async def upload_files(
             "arquivos_recebidos": list(paths.keys()),
             "load_ids": load_ids,
         }
+
+@router.get("/status/{load_id}")
+def get_upload_status(load_id: str):
+    db = get_db()
+    load_history = get_load_history(db, load_id)
+    
+    if not load_history:
+        raise HTTPException(status_code=404, detail=f"load_id '{load_id}' não encontrado.")
+    
+    response = {"load_id": load_id, "status": load_history["status"]}
+
+    if load_history["status"] == "ERROR":
+        response["error_message"] = load_history.get("error_message")
+
+    return response

--- a/apps/backend/src/repositories/load_history_repository.py
+++ b/apps/backend/src/repositories/load_history_repository.py
@@ -22,7 +22,7 @@ def update_load_history(
         load_id: str,
         status: str,
         extra_fields: dict | None = None
-) -> bool:
+    ) -> bool:
     
     update = {
         "$set":{
@@ -42,3 +42,6 @@ def update_load_history(
     except PyMongoError as e:
         logger.error(f"[load_history_repository] Erro ao atualizar: {e}")
         return False
+
+def get_load_history(db: Database, load_id: str) -> dict | None:
+    return db[COLLECTION_NAME].find_one({"load_id": load_id})

--- a/apps/backend/src/services/upload_service.py
+++ b/apps/backend/src/services/upload_service.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 from pymongo.database import Database
 
-from src.repositories.load_history_repository import insert_load_history, update_load_history
+from src.repositories.load_history_repository import (
+    insert_load_history,
+    update_load_history,
+    get_load_history
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +18,8 @@ COLLECTION_MAP = {
     "gbd": "gbd",
     "indicadores_continuidade": "distribution_indices",
     "indicadores_continuidade_limite": "conj",
-}
- 
- 
+    }
+
 def generate_load_id() -> str:
     return uuid.uuid4().hex
 
@@ -25,7 +28,7 @@ def build_load_document(
         file_key: str,
         source_file: str | None = None,
         batch_version: str | None = None
-) -> dict:
+    ) -> dict:
     return {
         "load_id": load_id,
         "collection_name": COLLECTION_MAP.get(file_key, file_key),
@@ -46,7 +49,7 @@ def build_load_document(
 def register_upload_start(
         db: Database,
         paths: dict[str, Path],
-) -> dict[str, str]:
+    ) -> dict[str, str]:
     registered = {}
     for file_key, file_path in paths.items():
         load_id = generate_load_id()
@@ -66,9 +69,24 @@ def run_etl_placeholder(
         db: Database,
         load_ids: dict[str, str],
         paths: dict[str, Path],
-) -> None:
+    ) -> None:
     for file_key, path in paths.items():
         logger.info(f"[upload_service] Pronto para extração: {file_key} → {path}")
         load_id = load_ids.get(file_key)
         if load_id:
             update_load_history(db, load_id, "SUCCESS")
+
+def get_upload_status(db: Database, load_id: str) -> dict | None:
+    load_history = get_load_history(db, load_id)
+    if not load_history:
+        return None
+    
+    response = {
+        "load_id": load_id,
+        "status": load_history["status"],
+    }
+
+    if load_history["status"] == "ERROR":
+        response["error_message"] = load_history.get("error_message")
+    
+    return response

--- a/docs/BACKEND_INFRASTRUCTURE.md
+++ b/docs/BACKEND_INFRASTRUCTURE.md
@@ -75,6 +75,8 @@ Dedicated to the **ETL (Extract, Transform, Load)** lifecycle for large datasets
 | Pandas | latest | Data processing for ETL flows |
 | Python | 3.11 | Base programming language |
 
+---
+
 ## 🔄 Lifecycle & Workflow
 
 The application follows a structured lifespan routine upon startup:
@@ -83,6 +85,8 @@ The application follows a structured lifespan routine upon startup:
 2. **Schema Setup**: Initializes collections and performs necessary validations
 3. **Data Seeding**: Runs seed.py to ensure core indicators and parameters are present
 4. **Route Registration**: Dynamically loads API endpoints
+
+---
 
 ## 🐳 Docker Configuration
 
@@ -93,6 +97,8 @@ The application follows a structured lifespan routine upon startup:
 | Exposed Port | `8000` |
 | Execution Command | `fastapi dev` (Optimized for development) |
 
+---
+
 ## 📊 Database Context (MongoDB)
 
 The repository manages specific collections for energy grid infrastructure and performance indicators:
@@ -100,6 +106,8 @@ The repository manages specific collections for energy grid infrastructure and p
 - **Network Structure**: `substations`, `distribution_transformers`, `at_network_segments`
 - **Indicators**: `distribution_indices` (DEC/FEC), `energy_losses_tariff`
 - **Consumer Data**: `consumer_units_pj`, `load_history`
+
+---
 
 ## 🚀 Available Scripts
 
@@ -109,6 +117,81 @@ The repository manages specific collections for energy grid infrastructure and p
 | `npm run test` | Executes the test suite using pytest |
 | `npm run build` | Placeholder for CI/CD pipeline checks |
 
+## 🔌 API Endpoint Documentation (Developer Reference)
+
+This section documents backend API endpoints for developers, including upload processing flow, validation rules, temporary storage behavior, and load tracking.
+
+### Upload Endpoints (`/upload`)
+
+- `POST /upload/` (status `202 Accepted`)
+    - Receives multipart files and starts asynchronous ETL processing.
+    - Accepted form fields:
+        - `energy_losses` (`.xlsx`)
+        - `gbd` (`.zip`, expected to contain a `.gdb` directory)
+        - `indicadores_continuidade` (`.csv`)
+        - `indicadores_continuidade_limite` (`.csv`)
+    - Response payload:
+        - `status`: upload execution state initialization (`STARTED`)
+        - `arquivos_recebidos`: list of successfully validated file keys
+        - `load_ids`: dictionary mapping `file_key -> load_id`
+
+- `GET /upload/status/{load_id}`
+    - Returns load execution status from `load_history`.
+    - Returns `404` when `load_id` does not exist.
+    - When status is `ERROR`, includes `error_message`.
+
+### Processing Flow
+
+1. The route creates a temporary upload folder using a generated `upload_id`.
+2. Each provided file is validated and read in memory.
+3. Valid files are persisted to disk under `tmp/uploads/{upload_id}`.
+4. For `gbd`, ZIP content is extracted into a dedicated directory and the `.gdb` path is used for ETL input.
+5. A `load_history` document is created per accepted file (`file_key`).
+6. A background task is scheduled to execute ETL processing.
+
+### Validation Rules
+
+- Extension validation per file key.
+- MIME validation using content-based detection (`python-magic`), not only filename metadata.
+- File size validation with configurable limit:
+    - `max_upload_size_mb` (default: `500`)
+- Empty upload protection:
+    - If no file is sent, request is rejected.
+- Dynamic file key support:
+    - Pattern `^indicadores_continuidade_\d{4}_\d{4}$` is accepted as CSV input.
+
+### ZIP/GBD Security and Integrity
+
+- ZIP traversal protection:
+    - Rejects entries containing `..` or absolute paths during extraction.
+- GBD content integrity:
+    - Rejects ZIP files that do not include a directory with `.gdb` suffix.
+
+### Error Contract
+
+- Validation failures are aggregated and returned as HTTP `422` with a list in `detail`.
+- Typical validation errors include:
+    - Unsupported file type for `file_key`
+    - Invalid extension
+    - Invalid detected MIME type
+    - File size limit exceeded
+    - Invalid ZIP/GBD structure
+
+### Configuration Parameters
+
+Upload behavior is controlled by backend settings:
+
+- `max_upload_size_mb`: maximum accepted upload size per file
+- `tmp_upload_path`: base path for temporary upload folders
+
+### Operational Notes for Developers
+
+- The current asynchronous worker function is a placeholder and marks load status as `SUCCESS` after scheduling flow execution.
+- Load tracking is stored in `load_history`, enabling status polling independent of request lifecycle.
+- Upload temporary folders are managed by context manager and cleaned up automatically.
+
 ---
 
-*Last updated: 04/17/2026*
+
+
+*Last updated: 04/20/2026*


### PR DESCRIPTION
## 🔗 Related Issue

Closes #110

---

## 📝 What was done?

- Implemented POST /upload/ to receive multipart files and return 202 Accepted when validation passes, starting ETL in background.
- Implemented file validation flow with explicit 422 responses for invalid files/types and clear error detail per file.
- Implemented [GET /upload/status/{load_id}](vscode-file://vscode-app/c:/Users/Cesar/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to return current processing status.
- Implemented 404 handling for non-existent [load_id](vscode-file://vscode-app/c:/Users/Cesar/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Added/organized technical endpoint documentation for upload behavior, validations, processing flow, error contract, and operational notes in [BACKEND_INFRASTRUCTURE.md](vscode-file://vscode-app/c:/Users/Cesar/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Replaced old infrastructure doc naming ([INFRASTRUCTURE.md](vscode-file://vscode-app/c:/Users/Cesar/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) with [BACKEND_INFRASTRUCTURE.md](vscode-file://vscode-app/c:/Users/Cesar/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to align documentation scope.

---

## 🧪 How to test locally

```# 1. Clean the environment
docker compose down -v

# 2. Start the environment again
docker compose --profile full --tools up

#3. Open the `http://localhost:8000/docs#/upload/upload_files_upload__post`
Select 1 or more efiles

#4. Upload the files and Check the results

Check the results on swagger
```

## ⚠️ Risks and Potential Impact

- Validation is stricter now; files previously accepted by extension/name only may now be rejected by MIME/content checks.
- Any consumer depending on non-standard upload payloads may need adjustment.
- Background ETL start is asynchronous; clients must rely on status polling via [load_id](vscode-file://vscode-app/c:/Users/Cesar/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

---

## 📸 Evidence

### Post Ok

<img width="1426" height="823" alt="Post Update Ok" src="https://github.com/user-attachments/assets/e8e1b113-7099-48b9-9d18-2f112f6f58fe" />

### Post N Ok

<img width="1419" height="689" alt="Upload Não Ok" src="https://github.com/user-attachments/assets/8d21eeef-e442-4386-a92c-53bd39131319" />

### Get Ok

<img width="1416" height="860" alt="Get Ok" src="https://github.com/user-attachments/assets/623840d0-fbf3-4129-8dbd-248a6177be33" />

### Get N Ok

<img width="1418" height="901" alt="Get NOk" src="https://github.com/user-attachments/assets/5e9d6dc4-d737-4b32-bed2-dcb179cb68cc" />

---