### PR TITLE
Fix/143 correction for file V007__rls_policies

### DIFF
--- a/database/migrations/V007__rls_policies.sql
+++ b/database/migrations/V007__rls_policies.sql
@@ -14,11 +14,11 @@ FOR SELECT
 USING (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 );
 
@@ -28,11 +28,11 @@ FOR INSERT
 WITH CHECK (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 );
 
@@ -42,21 +42,21 @@ FOR UPDATE
 USING (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 )
 WITH CHECK (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 );
 
@@ -81,11 +81,11 @@ FOR SELECT
 USING (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 );
 
@@ -95,11 +95,11 @@ FOR INSERT
 WITH CHECK (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 );
 
@@ -109,21 +109,21 @@ FOR UPDATE
 USING (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 )
 WITH CHECK (
     EXISTS (
         SELECT 1
-        FROM TB_USER current_user
-        JOIN TB_PROFILE current_profile
-          ON current_profile.PROFILE_UUID = current_user.PROFILE_ID
-        WHERE current_user.USER_UUID = current_setting('app.current_user_id')::UUID
-          AND current_profile.PROFILE_NAME = 'ADMIN'
+        FROM TB_USER auth_user
+        JOIN TB_PROFILE auth_profile
+          ON auth_profile.PROFILE_UUID = auth_user.PROFILE_ID
+        WHERE auth_user.USER_UUID = current_setting('app.current_user_id')::UUID
+          AND auth_profile.PROFILE_NAME = 'ADMIN'
     )
 );
 


### PR DESCRIPTION


## 🔗 Related Issue

> Auto-detected from branch. Confirm or edit if needed.
> Branch: `feature/143-feat-5-1-relational-database-restructuring` → Issue: #143 

Closes #143

---

## 📝 What was done?

> Explain what was implemented and why. Be specific about the approach taken.

- Fixed the Flyway error in `V007__rls_policies.sql` caused by the use of `current_user` as a table alias inside ADMIN RLS policies.
- Replaced the conflicting aliases with neutral names so PostgreSQL can parse the policy definitions correctly.

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

```bash
# 1. Reset the environment so PostgreSQL is recreated from scratch
docker compose down -v

# 2. Start the backend stack
docker compose --profile backend up --build
```

---

## ⚠️ Risks and Potential Impact

> Describe possible side effects or risks of this change.

- This fix changes a security-sensitive migration file, so any typo in the policy definitions can affect access control.
- If someone tests using an old persisted volume, they may not reproduce the original Flyway error or the fix correctly.

---

## 📸 Evidence

> Add screenshots, logs or relevant outputs.

<img width="1142" height="199" alt="image" src="https://github.com/user-attachments/assets/3e4a3e28-c6ec-4527-9be5-c584e76f502a" />

---

## ✅ Definition of Done

- [X] All acceptance criteria from the issue are met
- [X] Code reviewed before submitting

---

## ✅ Final Checklist

- [ ] My code follows the project style guide
- [X] I reviewed my own code before submitting
- [ ] I added comments for complex or non-obvious code
- [ ] Documentation updated if needed
- [X] My changes do not generate new warnings
- [ ] New and existing tests pass with my changes