### PR TITLE
Feature/205 calculate and persist the tam

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -4,6 +4,7 @@ from src.config.middleware import setup_middleware
 from src.api.routes import decfec
 from src.api.routes import energy_losses
 from src.api.routes import network_structure
+from src.api.routes import tam_sam
 from src.api.routes import upload
 
 from src.config.lifespan import lifespan
@@ -14,4 +15,5 @@ setup_middleware(app)
 app.include_router(decfec.router)
 app.include_router(energy_losses.router)
 app.include_router(network_structure.router)
+app.include_router(tam_sam.router)
 app.include_router(upload.router)

--- a/apps/backend/src/api/routes/tam_sam.py
+++ b/apps/backend/src/api/routes/tam_sam.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, HTTPException
+
+from src.control.tam_sam_procedures import Tam_sam_procedures
+
+router = APIRouter(prefix="/tam-sam", tags=["tam_sam"])
+
+
+@router.post("/calculate")
+async def calculate_tam_total():
+    return Tam_sam_procedures().calculate_and_persist_tam_total()
+
+
+@router.get("/")
+async def get_tam_total():
+    result = Tam_sam_procedures().get_tam_total()
+
+    if not result:
+        raise HTTPException(
+            status_code=404,
+            detail="TAM ainda nao calculado. Execute POST /tam-sam/calculate primeiro.",
+        )
+
+    return result

--- a/apps/backend/src/control/tam_sam_procedures.py
+++ b/apps/backend/src/control/tam_sam_procedures.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+import pymongo
+
+from src.config.settings import Settings
+from src.database.connection import get_client
+
+_settings = Settings()
+
+
+class Tam_sam_procedures:
+    connection: Optional[pymongo.MongoClient]
+    db: Optional[pymongo.database.Database]
+
+    def __init__(self, connection: Optional[pymongo.MongoClient] = None):
+        if connection is not None:
+            self.connection = connection
+        else:
+            self.connection = get_client()
+
+        self.db = self.connection[_settings.mongo_db_name]
+
+    def calculate_and_persist_tam_total(self):
+        pipeline = [
+            {"$match": {"consumer_unit_set_id": {"$nin": [None, ""]}}},
+            {"$group": {"_id": "$consumer_unit_set_id"}},
+            {"$count": "tam_total"},
+        ]
+
+        result = list(self.db.distribution_indices.aggregate(pipeline, allowDiskUse=True))
+        tam_total = int(result[0]["tam_total"]) if result else 0
+
+        calculated_on = datetime.now(timezone.utc)
+
+        self.db.tam_sam.update_one(
+            {"metric": "tam_total"},
+            {
+                "$set": {
+                    "metric": "tam_total",
+                    "tam_total": tam_total,
+                    "calculated_on": calculated_on,
+                }
+            },
+            upsert=True,
+        )
+
+        return {
+            "tam_total": tam_total,
+            "calculated_on": calculated_on.isoformat().replace("+00:00", "Z"),
+        }
+
+    def get_tam_total(self):
+        doc = self.db.tam_sam.find_one(
+            {"metric": "tam_total"},
+            {"_id": 0, "tam_total": 1, "calculated_on": 1},
+        )
+
+        if not doc:
+            return None
+
+        calculated_on = doc.get("calculated_on")
+        if isinstance(calculated_on, datetime):
+            doc["calculated_on"] = calculated_on.isoformat().replace("+00:00", "Z")
+
+        return doc

--- a/apps/backend/src/database/collections/tam_sam.py
+++ b/apps/backend/src/database/collections/tam_sam.py
@@ -1,0 +1,26 @@
+from pymongo import ASCENDING
+
+def setup_tam_sam(db):
+    db.create_collection(
+        "tam_sam",
+        validator={
+            "$jsonSchema": {
+                "bsonType": "object",
+                "properties": {
+                    "_id": {"bsonType": "objectId"},
+                    "tam_total": {
+                        "bsonType": ["int", "long", "null"],
+                        "description": "Total count of unique consumer unit sets used to calculate TAM."
+                    },
+                    "calculated_on": {
+                        "bsonType": "date",
+                        "description": "Date when the TAM was calculated. Mapped from CalculatedOn."
+                    }
+                }
+            }
+        },
+        validationLevel="strict",
+        validationAction="error"
+    )
+    db.tam_sam.create_index([("calculated_on", ASCENDING)], name="idx_calculated_on")
+    db.tam_sam.create_index([("metric", ASCENDING)], name="ux_metric", unique=True)

--- a/apps/backend/src/database/setup.py
+++ b/apps/backend/src/database/setup.py
@@ -9,6 +9,7 @@ from src.database.collections.load_history import setup_load_history
 from src.database.collections.mt_network_segments import setup_mt_network_segments
 from src.database.collections.municipalities import setup_municipalities
 from src.database.collections.substations import setup_substations
+from src.database.collections.tam_sam import setup_tam_sam
 
 COLLECTION_SETUPS = [
     ("at_network_segments",    setup_at_network_segments),
@@ -21,6 +22,7 @@ COLLECTION_SETUPS = [
     ("mt_network_segments",    setup_mt_network_segments),
     ("municipalities",         setup_municipalities),
     ("substations",            setup_substations),
+    ("tam_sam",                setup_tam_sam),
 ]
 
 def setup():

--- a/apps/backend/src/etl/extract/extract_decfec.py
+++ b/apps/backend/src/etl/extract/extract_decfec.py
@@ -36,13 +36,13 @@ def extract_decfec() -> Generator[tuple[pd.DataFrame, str], None, None]:
 #The list returned can be retrieved with commands such as "data_dict[1]" or data_dict[1]['UF']
 #Only the 'DatGeracaoConjuntoDados' column won't be used
 def extract_decfec_new():
-    file_name = os.getenv("CSV_FILE_NAME")
+    file_name = os.getenv("CSV_FILE_PATH")
     search_folder = os.getenv("TMP_UPLOAD_PATH")
 
     path_value = find_file_full_path(file_name, search_folder)
     
     if not path_value:
-        raise ValueError("CSV_FILE_NAME environment variable is not set.")
+        raise ValueError("CSV_FILE_PATH environment variable is not set.")
 
     path = Path(path_value)
 

--- a/apps/backend/src/etl/get_decfec_file.py
+++ b/apps/backend/src/etl/get_decfec_file.py
@@ -6,9 +6,9 @@ PREFERRED_FILENAME = "indicadores-continuidade-coletivos-2020-2029.csv"
 
 
 def get_filepath() -> str:
-    path_value = os.getenv("CSV_FILE_NAME")
+    path_value = os.getenv("CSV_FILE_PATH")
     if not path_value:
-        raise ValueError("CSV_FILE_NAME environment variable is not set.")
+        raise ValueError("CSV_FILE_PATH environment variable is not set.")
 
     path = Path(path_value)
 
@@ -26,14 +26,14 @@ def get_filepath() -> str:
 
         if len(csv_files) > 1:
             raise ValueError(
-                "CSV_FILE_NAME points to a directory with multiple CSV files. "
-                "Set CSV_FILE_NAME to a single file path."
+                "CSV_FILE_PATH points to a directory with multiple CSV files. "
+                "Set CSV_FILE_PATH to a single file path."
             )
 
         raise ValueError(
-            "CSV_FILE_NAME points to a directory, but no CSV files were found."
+            "CSV_FILE_PATH points to a directory, but no CSV files were found."
         )
 
     raise ValueError(
-        f"CSV_FILE_NAME does not exist: {path_value}"
+        f"CSV_FILE_PATH does not exist: {path_value}"
     )

--- a/apps/backend/src/etl/load/load_decfec.py
+++ b/apps/backend/src/etl/load/load_decfec.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pymongo import UpdateOne
 
 from src.config.settings import Settings
+from src.control.tam_sam_procedures import Tam_sam_procedures
 from src.database.connection import get_client
 from src.etl.extract.extract_decfec import extract_decfec
 
@@ -113,6 +114,8 @@ def load_decfec(
     )
 
     try:
+        tam_result = None
+
         for chunk_index, (chunk_df, source_file) in enumerate(extract_decfec(), start=1):
             chunk_start_perf = time.perf_counter()
             chunk_rows = len(chunk_df)
@@ -213,6 +216,8 @@ def load_decfec(
         finished_at = datetime.now(timezone.utc)
         final_status = "PARTIAL" if totals["rows_rejected"] > 0 else "SUCCESS"
 
+        tam_result = Tam_sam_procedures(connection=client).calculate_and_persist_tam_total()
+
         load_history.update_one(
             {"load_id": load_id},
             {"$set": {
@@ -227,6 +232,7 @@ def load_decfec(
             load_id=load_id,
             batch_version=batch_version,
             status=final_status,
+            tam_total=tam_result["tam_total"],
             duration_ms=round((time.perf_counter() - start_perf) * 1000, 2),
             totals=totals,
         )
@@ -262,6 +268,10 @@ def load_decfec(
         "source_file": source_file,
         "started_at": started_at.isoformat(),
         "finished_at": finished_at.isoformat(),
+        "tam_sam": {
+            "tam_total": tam_result["tam_total"] if tam_result else None,
+            "calculated_on": tam_result["calculated_on"] if tam_result else None,
+        },
         **totals,
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       retries: 5
 
   flyway:
-    image: flyway/flyway:9-alpine
+    image: flyway/flyway:12.4.0-alpine
     profiles:
       - backend
       - frontend
@@ -32,7 +32,7 @@ services:
       - envs/.env.postgres.${APP_ENV:-dev}
       - envs/.env.flyway.${APP_ENV:-dev}
     volumes:
-      - ./database/migrations:/flyway/sql
+      - ./database/migrations:/flyway/migrations
     networks:
       - db_network
     depends_on:

--- a/docs/INSTALLATION_MANUAL.md
+++ b/docs/INSTALLATION_MANUAL.md
@@ -70,7 +70,7 @@ The backend is located in `apps/backend` and the frontend in `apps/frontend`.
 
 ### 3.1 Data Folder
 
-The backend service mounts the local folder `./data` to `/app/data` inside the container. The `CSV_FILE_NAME` value must be set in `envs/.env.backend.{dev|prod}`.
+The backend service mounts the local folder `./data` to `/app/data` inside the container. The `CSV_FILE_PATH` value must be set in `envs/.env.backend.{dev|prod}`.
 
 **Important:** Place the CSV file with this name inside the `data` folder at the project root before running the ETL.
 
@@ -127,7 +127,7 @@ In `envs/.env.backend.dev`:
 
 BACKEND_URL=http://localhost:8000
 FRONTEND_URL=http://localhost:5173
-CSV_FILE_NAME=indicadores-continuidade-coletivos-2020-2029.csv
+CSV_FILE_PATH=indicadores-continuidade-coletivos-2020-2029.csv
 MONGO_MAX_POOL_SIZE=10
 MONGO_SERVER_SELECTION_TIMEOUT_MS=120000
 MONGO_CONNECT_TIMEOUT_MS=10000
@@ -231,7 +231,7 @@ Although the project's main flow is Docker-oriented, it is possible to install a
 | Frontend doesn't load | Frontend container didn't start or port 5173 is occupied | Check logs with `docker compose logs frontend` and free the port |
 | Swagger unavailable | Backend didn't start or crashed due to connection error | Check backend logs and credentials in `.env` |
 | Migration fails | Wrong PostgreSQL/Flyway parameters | Review `envs/.env.postgres.*` and `envs/.env.flyway.*` |
-| CSV processing fails | File not found or name mismatch | Confirm file in `data` folder and `CSV_FILE_NAME` |
+| CSV processing fails | File not found or name mismatch | Confirm file in `data` folder and `CSV_FILE_PATH |
 | Mongo connection error | Incompatible MongoDB username/password | Review `MONGO_*` in `envs/.env.mongo.*` and `envs/.env.backend.*` |
 
 ---

--- a/docs/USER_MANUAL.MD
+++ b/docs/USER_MANUAL.MD
@@ -135,7 +135,7 @@ GET http://localhost:8000/process-decfec
 ```
 
 The backend will:
-1. Read the file defined by `CSV_FILE_NAME` in `envs/.env.backend.{dev|prod}`
+1. Read the file defined by `CSV_FILE_PATH` in `envs/.env.backend.{dev|prod}`
 2. Call the `load_decfec.py` routine
 3. Apply the transformation step
 4. Record valid entries in MongoDB

--- a/envs/.env.backend.example
+++ b/envs/.env.backend.example
@@ -2,7 +2,7 @@
 APP_ENV=dev
 BACKEND_URL=http://localhost:8000
 FRONTEND_URL=http://localhost:5173
-CSV_FILE_NAME=indicadores-continuidade-coletivos-2020-2029.csv
+CSV_FILE_PATH=/app/data/indicadores-continuidade-coletivos-2020-2029.csv
 LOSSES_FILE_NAME=energy-losses.xlsx
 LIMITS_FILE_NAME=indicadores-continuidade-coletivos-limite.csv
 TMP_UPLOAD_PATH=/app/tmp

--- a/envs/.env.flyway.example
+++ b/envs/.env.flyway.example
@@ -1,6 +1,7 @@
 FLYWAY_URL=jdbc:postgresql://postgres:5432/tecsys
 FLYWAY_USER=admin
 FLYWAY_PASSWORD=password
+FLYWAY_LOCATIONS=filesystem:/flyway/migrations
 
 # In the real production Flyway env file, use:
 # FLYWAY_PLACEHOLDERS_seed_synthetic_data=false


### PR DESCRIPTION
## 🔗 Related Issue

Closes #205 

---

## 📝 What was done?

- Added TAM calculation based on the consumer_unit_set_id record count.

---

## 🧪 How to test locally

- Run ```/process-decfec```. Once the TAM is loaded, the calculation will run automatically.

## 📸 Evidence

<img width="646" height="341" alt="image" src="https://github.com/user-attachments/assets/4021a45c-a615-4f43-b653-cf8074afcb68" />

