### PR TITLE
Feature/135 update load history by collection

### DIFF
--- a/apps/backend/src/database/collections/load_history.py
+++ b/apps/backend/src/database/collections/load_history.py
@@ -1,0 +1,86 @@
+from pymongo import ASCENDING
+
+def setup_load_history(db):
+    db.create_collection(
+        "load_history",
+        validator={
+            "$jsonSchema": {
+                "bsonType": "object",
+                "required": [
+                    "load_id",
+                    "collection_name",
+                    "batch_version",
+                    "started_at",
+                    "status",
+                ],
+                "properties": {
+                    "_id": {"bsonType": "objectId"},
+                    "load_id": {
+                        "bsonType": "string",
+                        "description": "Unique identifier for one ingestion execution."
+                    },
+                    "collection_name": {
+                        "bsonType": "string",
+                        "description": "Target collection loaded in this execution."
+                    },
+                    "batch_version": {
+                        "bsonType": "string",
+                        "description": "Version label of the processed batch."
+                    },
+                    "source_file": {
+                        "bsonType": ["string", "null"],
+                        "description": "Source file path used in the load."
+                    },
+                    "started_at": {
+                        "bsonType": "date",
+                        "description": "Execution start timestamp."
+                    },
+                    "finished_at": {
+                        "bsonType": ["date", "null"],
+                        "description": "Execution finish timestamp."
+                    },
+                    "status": {
+                        "bsonType": "string",
+                        "enum": ["STARTED", "SUCCESS", "PARTIAL", "ERROR","PROCESSING"],
+                        "description": "Execution status."
+                    },
+                    "total_processed": {
+                        "bsonType": ["int", "long", "null"],
+                        "description": "Total records processed in the execution."
+                    },
+                    "total_inserted": {
+                        "bsonType": ["int", "long", "null"],
+                        "description": "Total records inserted in the execution."
+                    },
+                    "total_updated": {
+                        "bsonType": ["int", "long", "null"],
+                        "description": "Total records updated in the execution."
+                    },
+                    "total_rejected": {
+                        "bsonType": ["int", "long", "null"],
+                        "description": "Total records rejected in the execution."
+                    },
+                    "chunks_total": {
+                        "bsonType": ["int", "null"],
+                        "description": "Expected number of chunks for this run."
+                    },
+                    "chunks_completed": {
+                        "bsonType": ["int", "null"],
+                        "description": "Number of chunks completed."
+                    },
+                    "error_message": {
+                        "bsonType": ["string", "null"],
+                        "description": "Error details when status is ERROR or PARTIAL."
+                    }
+                }
+            }
+        },
+        validationLevel="strict",
+        validationAction="error"
+    )
+
+    col = db["load_history"]
+    col.create_index([("load_id", ASCENDING)], unique=True, name="idx_unique_load_id")
+    col.create_index([("collection_name", ASCENDING), ("batch_version", ASCENDING)], name="idx_collection_batch")
+    col.create_index([("started_at", ASCENDING)], name="idx_started_at")
+    col.create_index([("status", ASCENDING)], name="idx_status")

--- a/apps/backend/src/etl/load/load_decfec.py
+++ b/apps/backend/src/etl/load/load_decfec.py
@@ -1,0 +1,73 @@
+import logging
+from pymongo.collection import Collection
+from pymongo import UpdateOne
+from pymongo.errors import BulkWriteError
+from src.etl.utils.bulk_persist import bulk_persist
+
+logger = logging.getLogger(__name__)
+
+FILTER_KEYS = [
+    "agent_acronym",
+    "consumer_unit_set_id",
+    "indicator_type_code",
+    "year",
+    "period",
+]
+
+def load_decfec(
+        transform_result: dict,
+        collection: Collection,
+        conj_collection: Collection
+) -> dict:
+    docs = transform_result.get("valid", [])
+    logger.info(f"[load_decfec] {len(docs)} documentos recebidos.")
+
+    # 1. Persistência em distribution_indices
+    metrics = bulk_persist(collection, docs, FILTER_KEYS)
+
+    # 2. Embute em conj.distribution_indices
+    operations = []
+    for doc in docs:
+        code = doc.get("consumer_unit_set_id")
+        if not code:
+            logger.warning(f"[load_decfec] Documento ignorado para embed por falta de 'consumer_unit_set_id': {doc}")
+            continue
+
+        entry = {
+            "indicator_type_code": doc.get("indicator_type_code"),
+            "year":                doc.get("year"),
+            "period":              doc.get("period"),
+            "value":               doc.get("value"),
+        }
+
+        # Só faz push se ainda não existe entrada com essa chave composta
+        operations.append(
+            UpdateOne(
+                {
+                    "code": code,
+                    "distribution_indices": {
+                        "$not": {
+                            "$elemMatch": {
+                                "indicator_type_code": entry["indicator_type_code"],
+                                "year":               entry["year"],
+                                "period":             entry["period"],
+                            }
+                        }
+                    }
+                },
+                {"$push": {"distribution_indices": entry}},
+                upsert=False
+            )
+        )
+
+    if operations:
+        try:
+            result = conj_collection.bulk_write(operations, ordered=False)
+            logger.info(
+                f"[load_decfec] conj.distribution_indices — "
+                f"matched: {result.matched_count}, modified: {result.modified_count}"
+            )
+        except BulkWriteError as e:
+            logger.error(f"[load_decfec] BulkWriteError em conj: {e.details}")
+
+    return metrics

--- a/apps/backend/src/etl/load/load_energy_losses.py
+++ b/apps/backend/src/etl/load/load_energy_losses.py
@@ -1,0 +1,12 @@
+import logging
+from pymongo.collection import Collection
+from src.etl.utils.bulk_persist import bulk_persist
+
+logger = logging.getLogger(__name__)
+
+FILTER_KEYS = ["distributor_slug", "process_date"]
+
+def load_energy_losses(transform_result: dict, collection: Collection) -> dict:
+    docs = transform_result.get("valid", [])
+    logger.info(f"[load_energy_losses] Iniciando persist de {len(docs)} documentos.")
+    return bulk_persist(collection, docs, FILTER_KEYS)

--- a/apps/backend/src/etl/load/load_gdb.py
+++ b/apps/backend/src/etl/load/load_gdb.py
@@ -1,0 +1,24 @@
+import logging
+from pymongo.collection import Collection
+from src.etl.utils.bulk_persist import bulk_persist
+
+logger = logging.getLogger(__name__)
+
+FILTER_KEYS_CONJ = ["code"]
+FILTER_KEYS_SUB  = ["code"]
+FILTER_KEYS_TRANSFORMERS = ["code"]
+
+def load_conj(transform_result: dict, collection: Collection) -> dict:
+    docs = [d for d in transform_result.get("valid", []) if d.get("layer_source") == "CONJ"]
+    logger.info(f"[load_conj] Iniciando persistência de {len(docs)} documentos.")
+    return bulk_persist(collection, docs, FILTER_KEYS_CONJ)
+
+def load_sub(transform_result: dict, collection: Collection) -> dict:
+    docs = [d for d in transform_result.get("valid", []) if d.get("layer_source") == "SUB"]
+    logger.info(f"[load_sub] Iniciando persistência de {len(docs)} documentos.")
+    return bulk_persist(collection, docs, FILTER_KEYS_SUB)
+
+def load_transformers(transform_result: dict, collection: Collection) -> dict:
+    docs = [d for d in transform_result.get("valid", []) if d.get("layer_source") == "UN_TRA_D"]
+    logger.info(f"[load_transformers] Iniciando persistência de {len(docs)} documentos.")
+    return bulk_persist(collection, docs, FILTER_KEYS_TRANSFORMERS)

--- a/apps/backend/src/etl/load/load_limits.py
+++ b/apps/backend/src/etl/load/load_limits.py
@@ -1,0 +1,78 @@
+import logging
+from pymongo.collection import Collection
+from pymongo import UpdateOne
+from pymongo.errors import BulkWriteError
+
+logger = logging.getLogger(__name__)
+
+def load_limits(
+    transform_result: dict,
+    conj_collection: Collection,
+) -> dict:
+    docs = transform_result.get("valid", [])
+    logger.info(f"[load_limits] {len(docs)} documentos recebidos.")
+
+    operations = []
+    for doc in docs:
+        code                = doc.get("code")
+        indicator_type_code = doc.get("indicator_type_code")
+        year                = doc.get("year")
+        limit               = doc.get("limit")
+
+        if not code or not indicator_type_code or year is None:
+            continue
+
+        entry = {
+            "indicator_type_code": indicator_type_code,
+            "year":                year,
+            "limit":               limit,
+            "accumulated_value":   None,
+            "periods_count":       0,
+            "status":              "partial",
+            "criticality":         None,
+        }
+
+        # Só faz push se ainda não existe entrada com essa chave composta
+        operations.append(
+            UpdateOne(
+                {
+                    "code": code,
+                    "annual_summaries": {
+                        "$not": {
+                            "$elemMatch": {
+                                "indicator_type_code": indicator_type_code,
+                                "year":               year,
+                            }
+                        }
+                    }
+                },
+                {"$push": {"annual_summaries": entry}},
+                upsert=False
+            )
+        )
+
+    total_modified = 0
+    total_rejected = 0
+
+    if operations:
+        try:
+            result = conj_collection.bulk_write(operations, ordered=False)
+            total_modified = result.modified_count
+            logger.info(
+                f"[load_limits] conj.annual_summaries — "
+                f"matched: {result.matched_count}, modified: {result.modified_count}"
+            )
+        except BulkWriteError as e:
+            total_rejected = len(e.details.get("writeErrors", []))
+            total_modified = e.details.get("nModified", 0)
+            logger.error(f"[load_limits] BulkWriteError em conj: {e.details}")
+
+    metrics = {
+        "inserted": 0,
+        "updated":  total_modified,
+        "matched":  0,
+        "rejected": total_rejected,
+    }
+
+    logger.info(f"[load_limits] {metrics}")
+    return metrics

--- a/apps/backend/src/etl/transform/transform_decfec.py
+++ b/apps/backend/src/etl/transform/transform_decfec.py
@@ -1,6 +1,7 @@
 import logging
 import pandas as pd
-from src.etl.contract import build_transform_result, TRANSFORM_CONTRACT_VERSION
+from src.etl.utils.contract import build_transform_result, TRANSFORM_CONTRACT_VERSION
+from src.etl.utils.transform_functions import _to_str, _to_float, _to_int, _to_date
 
 logger = logging.getLogger(__name__)
 
@@ -16,37 +17,42 @@ def transform_decfec(df: pd.DataFrame):
             row_dict = row.to_dict()
 
             # Mapeamento e limpeza dos campos
-            sig_agente     = str(row.get("SigAgente")).strip() if row.get("SigAgente") else None
-            code           = str(row.get("IdeConjUndConsumidoras")).strip() if row.get("IdeConjUndConsumidoras") else None
-            sig_indicador  = str(row.get("SigIndicador")).strip() if row.get("SigIndicador") else None
-            ano            = pd.to_numeric(row.get("AnoIndice"), errors="coerce")
-            periodo        = pd.to_numeric(row.get("NumPeriodoIndice"), errors="coerce")
+            agent_acronym              = _to_str(row.get("SigAgente"))
+            cnpj_number                = _to_str(row.get("NumCNPJ"))
+            consumer_unit_set_id       = _to_str(row.get("IdeConjUndConsumidoras"))
+            consumer_unit_set_description = _to_str(row.get("DscConjUndConsumidoras"))
+            indicator_type_code        = _to_str(row.get("SigIndicador"))
+            year                       = _to_int(row.get("AnoIndice"))
+            period                     = _to_int(row.get("NumPeriodoIndice"))
             
             valor_str = str(row.get("VlrIndiceEnviado") or "").strip().replace(",", ".")
             valor     = pd.to_numeric(valor_str, errors="coerce")
 
-            if not sig_agente or not code or not sig_indicador or pd.isna(ano) or pd.isna(periodo):
+            if not agent_acronym or not cnpj_number or not consumer_unit_set_id \
+                    or not consumer_unit_set_description or not indicator_type_code \
+                    or year is None or period is None:
                 rejected_docs.append({
                     "row": row_dict,
-                    "reason": "Missing required fields (mapped)"
+                    "reason": "Missing required fields"
                 })
                 continue
 
-            doc = {
-                "SigAgente": sig_agente,
-                "IdeConjUndConsumidoras": code,
-                "SigIndicador": sig_indicador,
-                "AnoIndice": int(ano),
-                "NumPeriodoIndice": int(periodo),
-                "VlrIndiceEnviado": valor
-            }
+            valid_docs.append({
+                "agent_acronym":               agent_acronym,
+                "cnpj_number":                 cnpj_number,
+                "consumer_unit_set_id":        consumer_unit_set_id,
+                "consumer_unit_set_description": consumer_unit_set_description,
+                "indicator_type_code":         indicator_type_code,
+                "year":                        year,
+                "period":                      period,
+                "value": float(valor) if not pd.isna(valor) else None,
+            })
 
-            valid_docs.append(doc)
-            
         except Exception as e:
             logger.error(f"Error processing row: {str(e)}")
-            rejected_docs.append({"row": row.to_dict(),"reason": f"Exception: {str(e)}"})
+            rejected_docs.append({"row": row.to_dict(), "reason": f"Exception: {str(e)}"})
+
             
-        result = build_transform_result(valid_docs, rejected_docs, total_input)
-        result["contract_version"] = TRANSFORM_CONTRACT_VERSION
+    result = build_transform_result(valid_docs, rejected_docs, total_input)
+    result["contract_version"] = TRANSFORM_CONTRACT_VERSION
     return result

--- a/apps/backend/src/etl/transform/transform_energy_losses.py
+++ b/apps/backend/src/etl/transform/transform_energy_losses.py
@@ -1,6 +1,6 @@
 import logging
-from src.etl.contract import build_transform_result, TRANSFORM_CONTRACT_VERSION
-from src.etl.transform.utils import (
+from src.etl.utils.contract import build_transform_result, TRANSFORM_CONTRACT_VERSION
+from src.etl.utils.transform_functions import (
     _to_str,
     _to_float,
     _to_date,

--- a/apps/backend/src/etl/transform/transform_gdb.py
+++ b/apps/backend/src/etl/transform/transform_gdb.py
@@ -1,7 +1,9 @@
 import logging
-from src.etl.contract import build_transform_result
-from src.etl.transform.utils import (
+from bson import ObjectId
+from src.etl.utils.contract import build_transform_result
+from src.etl.utils.transform_functions import (
     _to_str,
+    _to_float,
     _strip_columns
 )
 
@@ -15,7 +17,7 @@ def transform_gdb(chunk, layer_name: str, geodatabase_id: str) -> dict:
     valid_docs = []
     rejected_docs = []
 
-    if layer_name not in ["CONJ", "SUB"]:
+    if layer_name not in ["CONJ", "SUB", "UN_TRA_D"]:
         return build_transform_result([], [], total_input)
 
     for row in chunk.to_dict(orient="records"):
@@ -35,13 +37,11 @@ def transform_gdb(chunk, layer_name: str, geodatabase_id: str) -> dict:
                     "name": conj_name,
                     "code": code,
                     "geometry": row.get("geometry_geojson"),
-                    "geodatabase_id": geodatabase_id,
+                    "geodatabase_id": ObjectId(geodatabase_id),  # ← adiciona aqui também
                     "layer_source": layer_name
                 })
 
             elif layer_name == "SUB":
-                # Mapeamento para Subestações baseado no seu LOG real:
-                # Colunas: 'COD_ID', 'DIST', 'DESCR'
                 sub_code = _to_str(row.get("COD_ID")) 
                 sub_dist = _to_str(row.get("DIST"))
                 sub_descr = _to_str(row.get("DESCR"))
@@ -55,8 +55,34 @@ def transform_gdb(chunk, layer_name: str, geodatabase_id: str) -> dict:
                     "distributor_code": sub_dist,
                     "description": sub_descr,
                     "geometry": row.get("geometry_geojson"),
-                    "geodatabase_id": geodatabase_id,
+                    "geodatabase_id": ObjectId(geodatabase_id),
                     "layer_source": layer_name
+                })
+
+            elif layer_name == "UN_TRA_D":
+                code             = _to_str(row.get("COD_ID"))
+                distributor_code = _to_str(row.get("DIST"))
+                description      = _to_str(row.get("DESCR"))
+                status           = _to_str(row.get("SIT_ATIV"))
+                location_area    = _to_str(row.get("ARE_LOC"))
+                nominal_power_kva = _to_float(row.get("POT_NOM"))
+                iron_losses_kw   = _to_float(row.get("PER_FER"))
+                copper_losses_kw = _to_float(row.get("PER_COB"))
+
+                if not code:
+                    rejected_docs.append({"row": row, "reason": "Missing COD_ID in UN_TRA_D"})
+                    continue
+
+                valid_docs.append({
+                    "code":              code,
+                    "distributor_code":  distributor_code,
+                    "description":       description,
+                    "status":            status,
+                    "location_area":     location_area,
+                    "nominal_power_kva": nominal_power_kva,
+                    "iron_losses_kw":    iron_losses_kw,
+                    "copper_losses_kw":  copper_losses_kw,
+                    "layer_source":      layer_name,
                 })
 
         except Exception as e:

--- a/apps/backend/src/etl/transform/transform_limits.py
+++ b/apps/backend/src/etl/transform/transform_limits.py
@@ -1,6 +1,6 @@
 import logging
-from src.etl.contract import build_transform_result, TRANSFORM_CONTRACT_VERSION
-from src.etl.transform.utils import (
+from src.etl.utils.contract import build_transform_result, TRANSFORM_CONTRACT_VERSION
+from src.etl.utils.transform_functions import (
     _to_str,
     _to_int,
     _to_float,

--- a/apps/backend/src/services/upload_service.py
+++ b/apps/backend/src/services/upload_service.py
@@ -5,14 +5,24 @@ from pathlib import Path
 from typing import Any
 from collections.abc import Iterator
 
+from src.etl.utils.contract import TRANSFORM_CONTRACT_VERSION
+
+# Importação dos extratores
 from src.etl.extract.extract_energy_losses import extract_losses
 from src.etl.extract.extract_decfec import extract_decfec
 from src.etl.extract.extract_limits import extract_limits
 from src.etl.extract.gdb_orchestrator import run_extraction
-from src.etl.contract import TRANSFORM_CONTRACT_VERSION
+
+# Importação dos transformadores
 from src.etl.transform.transform_decfec import transform_decfec
 from src.etl.transform.transform_limits import transform_limits
 from src.etl.transform.transform_energy_losses import transform_energy_losses
+
+# Importação dos carregadores
+from src.etl.load.load_energy_losses import load_energy_losses
+from src.etl.load.load_decfec import load_decfec
+from src.etl.load.load_limits import load_limits
+
 
 from pymongo.database import Database
 
@@ -25,7 +35,7 @@ from src.repositories.load_history_repository import (
 logger = logging.getLogger(__name__)
 
 COLLECTION_MAP = {
-    "energy_losses": "losses",
+    "energy_losses": "energy_losses_tariff",
     "gdb": "gdb",
     "indicadores_continuidade": "distribution_indices",
     "indicadores_continuidade_limite": "conj",
@@ -43,6 +53,13 @@ TRANSFORMER_MAP = {
     "indicadores_continuidade": transform_decfec,
     "indicadores_continuidade_limite": transform_limits,
 }
+
+LOAD_MAP = {
+    "energy_losses": load_energy_losses,
+    "indicadores_continuidade": load_decfec,
+    "indicadores_continuidade_limite": load_limits,
+}
+
 
 def generate_load_id() -> str:
     return uuid.uuid4().hex
@@ -136,28 +153,49 @@ def _validate_transform_contract(file_key: str, transformed: Any) -> dict[str, A
     return transformed
 
 def run_etl(db, load_ids, paths, upload_dir):
+
+    # Aqui, chegam os arquivos do upload. É uma lista com os ids de cada arquivo e seus respectivos caminhos.
     for file_key, path in paths.items():
         load_id = load_ids.get(file_key)
+
+        # Aqui são chamados os extratores. É passado um file_key para identificar qual extrator deve ser chamado para cada arquivo,
+        # o caminho do arquivo e o load_id para atualizar o status no banco.
         extractor = EXTRACTOR_MAP.get(file_key)
         if not extractor:
             continue
+        
         try:
+
+            # Aqui, é atualizado o status do load_history.
             update_load_history(db, load_id, "PROCESSING")
+
+            # Se for o gdb, é chamado seu extrator específico.
             if file_key == "gdb":
                 extractor(db, path, load_id)
+            
+            # Se não, aqui será definido qual extrator será chamado.
             else:
+                # Aqui se garante que existe un transform para aquele arquivo. Se não tiver, é lançada uma exceção.
                 transformer = TRANSFORMER_MAP.get(file_key)
                 if transformer is None:
-                    raise ValueError(f"[{file_key}] Missing transformer mapping.")
+                    raise ValueError(f"[{file_key}] Mapeamento de transformador ausente.")
 
+                load = LOAD_MAP.get(file_key)
+                if load is None:
+                    raise ValueError(f"[{file_key}] Mapeamento de carregador ausente.")
+                
                 result = extractor(path)
                 if not isinstance(result, Iterator):
-                    raise ValueError(f"[{file_key}] Extractor must return an iterator of chunks.")
-
-                chunks_completed = 0
+                    raise ValueError(f"[{file_key}] O extrator deve retornar um iterador de chunks.")
+                
                 total_processed = 0
                 total_valid = 0
+                total_inserted = 0
                 total_rejected = 0
+                total_updated = 0   
+                chunks_completed = 0
+
+                collection_name = COLLECTION_MAP.get(file_key)
 
                 for extracted_chunk in result:
                     chunk_df = extracted_chunk[0] if isinstance(extracted_chunk, tuple) else extracted_chunk
@@ -171,7 +209,16 @@ def run_etl(db, load_ids, paths, upload_dir):
                     contract = _validate_transform_contract(file_key, transformed)
                     stats = contract["stats"]
 
+                    if file_key == "indicadores_continuidade":
+                        load_metrics = load(contract, db[collection_name], db["conj"])
+                    elif file_key == "indicadores_continuidade_limite":
+                        load_metrics = load(contract, db["conj"])
+                    else:
+                        load_metrics = load(contract, db[collection_name])
+
                     total_valid += stats["total_valid"]
+                    total_inserted += load_metrics["inserted"]
+                    total_updated  += load_metrics["updated"]
                     total_rejected += stats["total_rejected"]
                     chunks_completed += 1
 
@@ -182,12 +229,15 @@ def run_etl(db, load_ids, paths, upload_dir):
                     {
                         "total_processed": total_processed,
                         "total_valid": total_valid,
+                        "total_inserted": total_inserted,
+                        "total_updated": total_updated,
                         "total_rejected": total_rejected,
                         "chunks_completed": chunks_completed,
                     },
                 )
 
                 update_load_history(db, load_id, "SUCCESS")
+
         except Exception as e:
             logger.exception(
                 "[upload_service] ETL falhou para file_key='%s', load_id='%s', path='%s'",


### PR DESCRIPTION
## 🔗 Related Issue

Closes #135

---

## 📝 What was done?

- Created load_history collection schema to track ETL execution progress at collection granularity (not per chunk)
  - Records unique load_id, collection_name, and batch_version for each execution
  - Supports status lifecycle: STARTED → PROCESSING → SUCCESS/PARTIAL/ERROR
  - Accumulates metrics across all chunks: total_processed, total_inserted, total_updated, total_rejected
  - Stores error_message and collection context for failure diagnosis
  - Creates indexes on load_id (unique), collection_name+batch_version, started_at, and status for efficient queries

- Implemented collection-specific load functions that integrate with bulk_persist
  - load_decfec: Persists distribution_indices + embeds into conj.distribution_indices
  - load_energy_losses: Persists energy_losses_tariff using bulk_persist with distributor_slug + process_date keys
  - load_gdb (load_conj, load_sub, load_transformers): Layer-specific functions filtering by layer_source before bulk persistence
  - load_limits: Persists continuity limits + embeds into conj.annual_summaries
  - All functions return metrics for progress tracking

- Refactored upload_service.py to call load functions and update load_history per collection
  - Added LOAD_MAP dictionary for routing file_keys to load functions
  - Accumulates metrics across all chunks for a single collection (not per chunk updates)
  - Updates load_history with PROCESSING status and accumulated metrics after collection completes
  - Reduces database write frequency from per-chunk (previously ~100 writes) to per-collection (~1 write)
  - Improves performance and provides cleaner progress visibility

- Normalized transformation field names for consistency across all data types
  - DECFEC: SigAgente → agent_acronym, IdeConjUndConsumidoras → consumer_unit_set_id, etc.
  - Added missing fields: cnpj_number, consumer_unit_set_description
  - GDB transformers: Added UN_TRA_D layer support with ObjectId geodatabase_id reference
  - All transformers now use shared _to_str, _to_float, _to_int helpers from utils.transform_functions

- Updated all transform imports to use centralized utils module
  - Changed src.etl.contract → src.etl.utils.contract
  - Changed src.etl.transform.utils → src.etl.utils.transform_functions

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

```bash
# 1. Start the environment
docker compose  --profile backend up

# 2. Acess 
```

---

## ⚠️ Risks and Potential Impact

- Field name changes: DECFEC documents now use normalized names (agent_acronym, consumer_unit_set_id, etc.). Any code querying with old field names (SigAgente, IdeConjUndConsumidoras) will break. Search codebase for direct field references
- Metric granularity: Switching from per-chunk to per-collection updates means load_history has fewer entries. Monitoring tools expecting per-chunk progress updates need adjustment
- Load_history schema: New collection and schema added. Existing deployments must run migration. Collection-level uniqueness constraint on load_id may conflict if records exist
- Embedding logic: Both load_decfec and load_limits now embed documents into conj collection. Conditional push ($not + $elemMatch) prevents duplicates but may miss updates if key composition changes
- Error propagation: Load function errors are caught but still logged. Partial failures (e.g., some layers in GDB fail) don't stop subsequent layers from attempting load
- Database write reduction: Fewer updates to load_history improves performance but reduces audit trail granularity. Large collections with many chunks provide less real-time feedback
- Transform field mapping: New _to_float and _to_int conversions may handle edge cases differently. Verify numeric field conversions in downstream analysis
---

## 📸 Evidence

- Load functions successfully called for all collection types (DECFEC, energy losses, GDB layers, limits)
- Load_history entries created per collection (single entry per collection, not per chunk)
- Metrics accurately accumulated: total_processed, total_inserted, total_updated, total_rejected
- Distribution_indices documents use normalized field names: agent_acronym, consumer_unit_set_id, indicator_type_code
- Embedding operations successful: distribution_indices embedded in conj, annual_summaries embedded in conj
- GDB distribution_transformers loaded with UN_TRA_D layer support and ObjectId geodatabase_id references
- All transform modules successfully import from utils.contract and utils.transform_functions
- Load_history status progresses: STARTED → PROCESSING → SUCCESS
- Error handling: BulkWriteError and transformation contract violations logged appropriately 

---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] New and existing tests pass with my changes