### PR TITLE
Feature/139 record the reconciliation result in load history

### DIFF
--- a/apps/backend/src/api/routes/upload.py
+++ b/apps/backend/src/api/routes/upload.py
@@ -8,6 +8,7 @@ from src.services.upload_service import (
     register_upload_start,
     run_etl,
     get_upload_status as fetch_upload_status,
+    get_batch_status as fetch_batch_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,15 +32,15 @@ async def upload_files(
     }
 
     db = get_db()
-    upload_id = generate_load_id()  # ← só para a pasta temp
-    upload_dir = create_upload_dir(upload_id)
+    batch_id  = generate_load_id()
+    upload_dir = create_upload_dir(batch_id)
 
     paths, errors = await process_uploaded_zip(upload_dir, files)
 
     if errors:
         raise HTTPException(status_code=422, detail=errors)
 
-    load_ids = register_upload_start(db, paths)
+    load_ids = register_upload_start(db, paths, batch_id)
 
     background_tasks.add_task(run_etl, db, load_ids, paths, upload_dir)
 
@@ -47,9 +48,20 @@ async def upload_files(
 
     return {
         "status": "STARTED",
+        "batch_id": batch_id, 
         "arquivos_recebidos": list(paths.keys()),
             "load_ids": load_ids,
         }
+
+@router.get("/batch/{batch_id}")
+def get_batch_status_endpoint(batch_id: str):
+    db = get_db()
+    result = fetch_batch_status(db, batch_id)
+
+    if not result:
+        raise HTTPException(status_code=404, detail=f"batch_id '{batch_id}' não encontrado.")
+
+    return result
 
 @router.get("/status/{load_id}")
 def get_upload_status(load_id: str):
@@ -60,3 +72,4 @@ def get_upload_status(load_id: str):
         raise HTTPException(status_code=404, detail=f"load_id '{load_id}' não encontrado.")
 
     return status
+

--- a/apps/backend/src/database/collections/load_history.py
+++ b/apps/backend/src/database/collections/load_history.py
@@ -41,8 +41,12 @@ def setup_load_history(db):
                     },
                     "status": {
                         "bsonType": "string",
-                        "enum": ["STARTED", "SUCCESS", "PARTIAL", "ERROR","PROCESSING"],
+                        "enum": ["STARTED", "SUCCESS", "PARTIAL", "ERROR", "PROCESSING", "SUCCESS_WITH_WARNINGS"],  # ← adicionar
                         "description": "Execution status."
+                    },
+                    "batch_id": {
+                        "bsonType": ["string", "null"],
+                        "description": "Groups multiple loads from the same upload."
                     },
                     "total_processed": {
                         "bsonType": ["int", "long", "null"],

--- a/apps/backend/src/etl/extract/gdb_orchestrator.py
+++ b/apps/backend/src/etl/extract/gdb_orchestrator.py
@@ -115,10 +115,12 @@ def run_extraction(db: Database, path: Path, load_id: str):
             update_load_history(db, load_id, "PROCESSING", current_metrics)
             
         final_metrics = {
-            "total_processed": total_processed,
-            "total_valid": total_valid,
-            "total_rejected": total_rejected,
-            "chunks_completed": chunks_completed
+            "total_processed":  total_processed,
+            "total_valid":      total_valid,
+            "total_rejected":   total_rejected,
+            "chunks_completed": chunks_completed,
+            "total_inserted":   total_inserted,
+            "total_updated":    total_updated,
         }
 
         logger.info(f"[DONE] Enviando métricas finais: {final_metrics}")

--- a/apps/backend/src/etl/load/load_decfec.py
+++ b/apps/backend/src/etl/load/load_decfec.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from pymongo.collection import Collection
 from pymongo import UpdateOne
@@ -5,6 +6,8 @@ from pymongo.errors import BulkWriteError
 from src.etl.utils.bulk_persist import bulk_persist
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 1000
 
 FILTER_KEYS = [
     "agent_acronym",
@@ -40,7 +43,6 @@ def load_decfec(
             "value":               doc.get("value"),
         }
 
-        # Só faz push se ainda não existe entrada com essa chave composta
         operations.append(
             UpdateOne(
                 {
@@ -61,12 +63,15 @@ def load_decfec(
         )
 
     if operations:
+        batch_size = int(os.getenv("ETL_BULK_PERSIST_BATCH_SIZE", DEFAULT_BATCH_SIZE))
         try:
-            result = conj_collection.bulk_write(operations, ordered=False)
-            logger.info(
-                f"[load_decfec] conj.distribution_indices — "
-                f"matched: {result.matched_count}, modified: {result.modified_count}"
-            )
+            for i in range(0, len(operations), batch_size):
+                batch = operations[i:i + batch_size]
+                result = conj_collection.bulk_write(batch, ordered=False)
+                logger.info(
+                    f"[load_decfec] conj.distribution_indices batch {i//batch_size + 1} — "
+                    f"matched: {result.matched_count}, modified: {result.modified_count}"
+                )
         except BulkWriteError as e:
             logger.error(f"[load_decfec] BulkWriteError em conj: {e.details}")
 

--- a/apps/backend/src/etl/load/load_energy_losses.py
+++ b/apps/backend/src/etl/load/load_energy_losses.py
@@ -4,9 +4,13 @@ from src.etl.utils.bulk_persist import bulk_persist
 
 logger = logging.getLogger(__name__)
 
-FILTER_KEYS = ["distributor_slug", "process_date"]
+FILTER_KEYS = ["distributor", "process_date"]
+
 
 def load_energy_losses(transform_result: dict, collection: Collection) -> dict:
     docs = transform_result.get("valid", [])
-    logger.info(f"[load_energy_losses] Iniciando persist de {len(docs)} documentos.")
-    return bulk_persist(collection, docs, FILTER_KEYS)
+
+    clean_docs = [{k: v for k, v in doc.items() if k != "distributor_slug"} for doc in docs]
+    
+    logger.info(f"[load_energy_losses] Iniciando persist de {len(clean_docs)} documentos.")
+    return bulk_persist(collection, clean_docs, FILTER_KEYS)

--- a/apps/backend/src/etl/load/load_limits.py
+++ b/apps/backend/src/etl/load/load_limits.py
@@ -1,9 +1,12 @@
+import os
 import logging
 from pymongo.collection import Collection
 from pymongo import UpdateOne
 from pymongo.errors import BulkWriteError
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 1000
 
 def load_limits(
     transform_result: dict,
@@ -13,6 +16,7 @@ def load_limits(
     logger.info(f"[load_limits] {len(docs)} documentos recebidos.")
 
     operations = []
+
     for doc in docs:
         code                = doc.get("code")
         indicator_type_code = doc.get("indicator_type_code")
@@ -32,7 +36,6 @@ def load_limits(
             "criticality":         None,
         }
 
-        # Só faz push se ainda não existe entrada com essa chave composta
         operations.append(
             UpdateOne(
                 {
@@ -55,16 +58,19 @@ def load_limits(
     total_rejected = 0
 
     if operations:
+        batch_size = int(os.getenv("ETL_BULK_PERSIST_BATCH_SIZE", DEFAULT_BATCH_SIZE))
         try:
-            result = conj_collection.bulk_write(operations, ordered=False)
-            total_modified = result.modified_count
-            logger.info(
-                f"[load_limits] conj.annual_summaries — "
-                f"matched: {result.matched_count}, modified: {result.modified_count}"
-            )
+            for i in range(0, len(operations), batch_size):
+                batch = operations[i:i + batch_size]
+                result = conj_collection.bulk_write(batch, ordered=False)
+                total_modified += result.modified_count
+                logger.info(
+                    f"[load_limits] conj.annual_summaries batch {i//batch_size + 1} — "
+                    f"matched: {result.matched_count}, modified: {result.modified_count}"
+                )
         except BulkWriteError as e:
-            total_rejected = len(e.details.get("writeErrors", []))
-            total_modified = e.details.get("nModified", 0)
+            total_rejected += len(e.details.get("writeErrors", []))
+            total_modified += e.details.get("nModified", 0)
             logger.error(f"[load_limits] BulkWriteError em conj: {e.details}")
 
     metrics = {

--- a/apps/backend/src/etl/reconcile/reconcile.py
+++ b/apps/backend/src/etl/reconcile/reconcile.py
@@ -1,0 +1,80 @@
+import logging
+from pymongo.database import Database
+
+logger = logging.getLogger(__name__)
+
+RECONCILIATION_CHECKS = {
+    "indicadores_continuidade": ["indicadores_conjunto"],
+}
+
+def _check_indicadores_conjunto(db: Database) -> dict:
+    """
+    Para cada consumer_unit_set_id em distribution_indices,
+    verifica se existe um documento com aquele code em conj.
+    """
+    pipeline = [
+        {"$group": {"_id": "$consumer_unit_set_id"}},
+    ]
+    set_ids = [
+        doc["_id"]
+        for doc in db["distribution_indices"].aggregate(pipeline)
+        if doc["_id"]
+    ]
+
+    checked = len(set_ids)
+    if checked == 0:
+        return {"checked": 0, "valid": 0, "invalid": 0}
+
+    existing_codes = set(
+        doc["code"]
+        for doc in db["conj"].find(
+            {"code": {"$in": set_ids}},
+            {"code": 1, "_id": 0}
+        )
+    )
+
+    valid   = sum(1 for sid in set_ids if sid in existing_codes)
+    invalid = checked - valid
+
+    return {"checked": checked, "valid": valid, "invalid": invalid}
+
+
+CHECKS_MAP = {
+    "indicadores_conjunto": _check_indicadores_conjunto,
+}
+
+
+def run_reconciliation(db: Database, file_key: str, load_id: str) -> dict:
+    """
+    Executa as checagens de reconciliação para o file_key informado.
+    Retorna o resultado e salva no load_history.
+    """
+    checks_to_run = RECONCILIATION_CHECKS.get(file_key, [])
+
+    if not checks_to_run:
+        logger.info(f"[reconcile] Nenhuma checagem definida para '{file_key}'.")
+        return {}
+
+    results = {}
+    has_warnings = False
+
+    for check_name in checks_to_run:
+        check_fn = CHECKS_MAP.get(check_name)
+        if not check_fn:
+            logger.warning(f"[reconcile] Checagem '{check_name}' não encontrada.")
+            continue
+
+        result = check_fn(db)
+        results[check_name] = result
+
+        if result.get("invalid", 0) > 0:
+            has_warnings = True
+
+        logger.info(f"[reconcile] '{check_name}' — {result}")
+
+    reconciliation = {
+        "status":  "WARNING" if has_warnings else "OK",
+        "results": results,
+    }
+
+    return reconciliation

--- a/apps/backend/src/repositories/load_history_repository.py
+++ b/apps/backend/src/repositories/load_history_repository.py
@@ -28,12 +28,18 @@ def update_load_history(
         "status": status,
         "finished_at": datetime.now(timezone.utc)
     }
+
+    ROOT_FIELDS = {"reconciliation"}
+
     if status == "SUCCESS" or status == "ERROR":
         update_data["finished_at"] = datetime.now(timezone.utc)
 
     if extra_fields:
         for key, value in extra_fields.items():
-            update_data[f"metrics.{key}"] = value
+            if key in ROOT_FIELDS:
+                update_data[key] = value
+            else:
+                update_data[f"metrics.{key}"] = value
 
     update = {"$set": update_data}
 
@@ -55,3 +61,6 @@ def update_load_history(
 
 def get_load_history(db: Database, load_id: str) -> dict | None:
     return db[COLLECTION_NAME].find_one({"load_id": load_id})
+
+def get_load_history_by_batch(db: Database, batch_id: str) -> list[dict]:
+    return list(db[COLLECTION_NAME].find({"batch_id": batch_id}))

--- a/apps/backend/src/services/upload_service.py
+++ b/apps/backend/src/services/upload_service.py
@@ -7,6 +7,8 @@ from collections.abc import Iterator
 
 from src.etl.utils.contract import TRANSFORM_CONTRACT_VERSION
 
+from src.etl.reconcile.reconcile import run_reconciliation
+
 # Importação dos extratores
 from src.etl.extract.extract_energy_losses import extract_losses
 from src.etl.extract.extract_decfec import extract_decfec
@@ -123,7 +125,6 @@ def register_upload_start(
         else:
             logger.error(f"[upload_service] Falha ao registrar load_history para '{file_key}'")
     return registered
-
 
 def _validate_transform_contract(file_key: str, transformed: Any) -> dict[str, Any]:
     if not isinstance(transformed, dict):
@@ -258,7 +259,18 @@ def run_etl(db, load_ids, paths, upload_dir):
                     },
                 )
 
-                update_load_history(db, load_id, "SUCCESS")
+                reconciliation = run_reconciliation(db, file_key, load_id)
+
+                final_status = "SUCCESS"
+                if reconciliation.get("status") == "WARNING":
+                    final_status = "SUCCESS_WITH_WARNINGS"
+
+                update_load_history(
+                    db,
+                    load_id,
+                    final_status,
+                    {"reconciliation": reconciliation} if reconciliation else None,
+                )
 
         except Exception as e:
             logger.exception(


### PR DESCRIPTION
## 🔗 Related Issue

Closes #139

---

## 📝 What was done?

- Implemented batch-level upload tracking system: Refactored the upload mechanism to use batch_id for grouping multiple files under a unified identifier, replacing the previous approach of tracking files only by individual load_id.
- Created consolidated batch status endpoint: Added GET /upload/batch/{batch_id} endpoint that returns the status of all files within a batch in a single response, including per-file metrics and reconciliation data.
- Enhanced database repository: Added get_load_history_by_batch() function to retrieve all load history records associated with a specific batch_id.
- Improved parameter propagation: Modified register_upload_start() to accept and persist batch_id in each load history record, linking individual loads to their parent batch.
- Implemented data reconciliation step: After each file load, a reconciliation step runs automatically to verify reference integrity between collections. Results are stored in load_history under the reconciliation field.
- Added SUCCESS_WITH_WARNINGS status: When reconciliation detects inconsistencies, the load is marked as SUCCESS_WITH_WARNINGS instead of SUCCESS, allowing clients to distinguish between clean and inconsistent loads.
- Refined API response: Added batch_id to the upload response payload so clients can immediately start polling the batch endpoint.

Why: This consolidates batch-level metadata management, improves API semantics, enables front-end to monitor all files in a single polling request, and gives users visibility into data quality immediately after upload.

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

```bash
# 1. Start the environment
docker compose --profile full --profile tools up

# 2. Access http://localhost:8000/docs#/upload/upload_files_upload__post

# 3. Upload the files:
- Base de Dados das Perdas de Energia nos Processos Tarifários
- EDP_SP_391_2016-12-31_M6_20170707-0903.gdb
- indicadores-continuidade-coletivos-2020-2029
- indicadores-continuidade-coletivos-limite

# 4. Copy the batch_id from the upload response

# 5. Access http://localhost:8000/docs#/upload/get_batch_status_upload_batch__batch_id__get
#    and paste the batch_id to poll the batch status

# 6. Wait for all files to reach SUCCESS or SUCCESS_WITH_WARNINGS
#    and verify the reconciliation field is populated for distribution_indices
```

---

## ⚠️ Risks and Potential Impact

> Describe possible side effects or risks of this change.

- 

---

## 📸 Evidence

Response body upload:

```
{
  "status": "STARTED",
  "batch_id": "f4dd75185cc74efbae3ebef6f71d9600",  <- batch id
  "arquivos_recebidos": [
    "energy_losses",
    "gdb",
    "indicadores_continuidade",
    "indicadores_continuidade_limite"
  ],
  "load_ids": {
    "energy_losses": "71296f61b88b4deb9c4e82766bd5bae5",
    "gdb": "512ff7cffd194c0c8e9c87caec0faa10",
    "indicadores_continuidade": "18f2905e8b784d6a9a525752e85ddede",
    "indicadores_continuidade_limite": "bacba235b2e343b68d6809747ad0d8aa"
  }
}

```

Response get batch:

```
{
  "batch_id": "f4dd75185cc74efbae3ebef6f71d9600",
  "status": "SUCCESS_WITH_WARNINGS",
  "files": {
    "energy_losses_tariff": {
      "load_id": "71296f61b88b4deb9c4e82766bd5bae5",
      "status": "SUCCESS",
      "metrics": {
        "total_processed": 631,
        "total_valid": 631,
        "total_inserted": 631,
        "total_updated": 0,
        "total_rejected": 0,
        "chunks_completed": 1
      },
      "reconciliation": null
    },
    "gdb": {
      "load_id": "512ff7cffd194c0c8e9c87caec0faa10",
      "status": "SUCCESS",
      "metrics": {
        "total_processed": 61375,
        "total_valid": 61375,
        "total_inserted": 61375,
        "total_updated": 0,
        "total_rejected": 0,
        "chunks_completed": 615
      },
      "reconciliation": null
    },
    "distribution_indices": {
      "load_id": "18f2905e8b784d6a9a525752e85ddede",
      "status": "SUCCESS_WITH_WARNINGS",
      "metrics": {
        "total_processed": 456114,
        "total_valid": 456114,
        "total_inserted": 456114,
        "total_updated": 0,
        "total_rejected": 0,
        "chunks_completed": 48
      },
      "reconciliation": {
        "status": "WARNING",
        "results": {
          "indicadores_conjunto": {
            "checked": 3978,
            "valid": 17,
            "invalid": 3961
          }
        }
      }
    },
    "conj": {
      "load_id": "bacba235b2e343b68d6809747ad0d8aa",
      "status": "SUCCESS",
      "metrics": {
        "total_processed": 262557,
        "total_valid": 262517,
        "total_inserted": 0,
        "total_updated": 948,
        "total_rejected": 40,
        "chunks_completed": 3
      },
      "reconciliation": null
    }
  }
}
```

IMPORTANT:

- Overall Status: SUCCESS_WITH_WARNINGS
All 4 files were processed and persisted successfully. The warning flag was raised because the continuity indicators dataset contains references to consumer unit sets that do not exist in the current geographic database.

- energy_losses_tariff — SUCCESS
631 tariff records were inserted with no issues. No reconciliation is performed for this collection as it has no cross-collection references.

- gdb — SUCCESS
61,375 geographic features were processed across all layers (CONJ, SUB, UN_TRA_D). All records were inserted successfully. No reconciliation is performed at the GDB level since it is the reference source for other collections.

- distribution_indices — SUCCESS_WITH_WARNINGS
456,114 continuity indicator records (DEC/FEC) were inserted successfully. However, the reconciliation step detected that 3,961 out of 3,978 unique consumer unit set IDs do not have a corresponding entry in the conj collection.
This is expected behavior: the indicators CSV contains data from all Brazilian distributors, while the GDB loaded covers only EDP SP. The 17 valid references correspond to the 52 EDP SP sets present in the database. Records from other distributors are stored in distribution_indices and will be linked to conj once their respective GDB files are uploaded.

- conj — SUCCESS
262,517 limit records were processed. 948 documents in conj were enriched with annual_summaries data from the limits CSV, and the distribution_indices array was populated for the EDP SP sets that matched. 40 records were rejected due to missing required fields in the source file.


---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] New and existing tests pass with my changes