### PR TITLE
Feature/140 add temporary directory cleanup and reconciliation in …

### DIFF
--- a/apps/backend/src/services/upload_service.py
+++ b/apps/backend/src/services/upload_service.py
@@ -171,34 +171,28 @@ def _validate_transform_contract(file_key: str, transformed: Any) -> dict[str, A
 
     return transformed
 
+import shutil
+
 def run_etl(db, load_ids, paths, upload_dir):
 
     ordered_keys = [k for k in PROCESSING_ORDER if k in paths]
     remaining = [k for k in paths if k not in PROCESSING_ORDER]
     ordered_paths = {k: paths[k] for k in ordered_keys + remaining}
 
-    # Aqui, chegam os arquivos do upload. É uma lista com os ids de cada arquivo e seus respectivos caminhos.
     for file_key, path in ordered_paths.items():
         load_id = load_ids.get(file_key)
 
-        # Aqui são chamados os extratores. É passado um file_key para identificar qual extrator deve ser chamado para cada arquivo,
-        # o caminho do arquivo e o load_id para atualizar o status no banco.
         extractor = EXTRACTOR_MAP.get(file_key)
         if not extractor:
             continue
         
         try:
-
-            # Aqui, é atualizado o status do load_history.
             update_load_history(db, load_id, "PROCESSING")
 
-            # Se for o gdb, é chamado seu extrator específico.
             if file_key == "gdb":
                 extractor(db, path, load_id)
             
-            # Se não, aqui será definido qual extrator será chamado.
             else:
-                # Aqui se garante que existe un transform para aquele arquivo. Se não tiver, é lançada uma exceção.
                 transformer = TRANSFORMER_MAP.get(file_key)
                 if transformer is None:
                     raise ValueError(f"[{file_key}] Mapeamento de transformador ausente.")
@@ -286,6 +280,15 @@ def run_etl(db, load_ids, paths, upload_dir):
                 {"error_message": f"[{file_key}] {e.__class__.__name__}: {e}"},
             )
 
+    # Limpeza da pasta temporária após o processamento de todos os arquivos
+    try:
+        upload_path = Path(upload_dir)
+        if upload_path.exists():
+            shutil.rmtree(upload_path)
+            logger.info(f"[run_etl] Pasta temporária removida: {upload_dir}")
+    except Exception as e:
+        logger.warning(f"[run_etl] Falha ao remover pasta temporária '{upload_dir}': {e}")
+        
 def get_upload_status(db: Database, load_id: str) -> dict | None:
     load_history = get_load_history(db, load_id)
     
@@ -315,7 +318,8 @@ def get_upload_status(db: Database, load_id: str) -> dict | None:
                 else load_history.get("total_rejected")
             ),
             "chunks_completed": db_metrics.get("chunks_completed") or load_history.get("chunks_completed"),
-        }
+        },
+        "reconciliation": load_history.get("reconciliation"),  # ← adicionar
     }
 
     logger.info(f"[FETCH_STATUS] Resposta final montada: {response}")


### PR DESCRIPTION
## 🔗 Related Issue

Closes #140

---

## 📝 What was done?

- Exposed reconciliation data in individual status endpoint: Updated GET /upload/status/{load_id} to include the reconciliation field in the response, allowing clients to check reference integrity results per file.
- Confirmed batch endpoint already includes reconciliation: GET /upload/batch/{batch_id} already returns reconciliation per file as part of the consolidated response implemented in the previous task.
- Added SUCCESS_WITH_WARNINGS as a valid status: Updated the load_history schema enum to include SUCCESS_WITH_WARNINGS, preventing validator rejections when the reconciliation step detects inconsistencies.
- Added temporary folder cleanup: After all files in a batch are processed, the temporary upload directory is automatically removed via shutil.rmtree, preventing disk accumulation across multiple uploads.

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

```bash
# 1. Start the environment
docker compose --profile full --profile tools up

# 2. Access http://localhost:8000/docs#/upload/upload_files_upload__post
#    and upload one or more files

# 3. Copy the load_id of a specific file from the response

# 4. Access GET /upload/status/{load_id} and confirm the reconciliation field appears in the response

# 5. Access GET /upload/batch/{batch_id} and confirm reconciliation appears per file

# 6. After processing completes, verify that the temporary folder under /app/tmp has been removed
```

---

## ⚠️ Risks and Potential Impact

- The temporary folder cleanup runs after all files are processed regardless of individual file status — if one file fails, the folder is still removed. This is intentional since partial data is already persisted in MongoDB.
- If the cleanup itself fails, a warning is logged but the ETL result is not af

---

## 📸 Evidence
Response body upload:

```
{
  "status": "STARTED",
  "batch_id": "f4dd75185cc74efbae3ebef6f71d9600",  <- batch id
  "arquivos_recebidos": [
    "energy_losses",
    "gdb",
    "indicadores_continuidade",
    "indicadores_continuidade_limite"
  ],
  "load_ids": {
    "energy_losses": "71296f61b88b4deb9c4e82766bd5bae5",
    "gdb": "512ff7cffd194c0c8e9c87caec0faa10",
    "indicadores_continuidade": "18f2905e8b784d6a9a525752e85ddede",
    "indicadores_continuidade_limite": "bacba235b2e343b68d6809747ad0d8aa"
  }
}

```

Response get batch:

```
{
  "batch_id": "f4dd75185cc74efbae3ebef6f71d9600",
  "status": "SUCCESS_WITH_WARNINGS",
  "files": {
    "energy_losses_tariff": {
      "load_id": "71296f61b88b4deb9c4e82766bd5bae5",
      "status": "SUCCESS",
      "metrics": {
        "total_processed": 631,
        "total_valid": 631,
        "total_inserted": 631,
        "total_updated": 0,
        "total_rejected": 0,
        "chunks_completed": 1
      },
      "reconciliation": null
    },
    "gdb": {
      "load_id": "512ff7cffd194c0c8e9c87caec0faa10",
      "status": "SUCCESS",
      "metrics": {
        "total_processed": 61375,
        "total_valid": 61375,
        "total_inserted": 61375,
        "total_updated": 0,
        "total_rejected": 0,
        "chunks_completed": 615
      },
      "reconciliation": null
    },
    "distribution_indices": {
      "load_id": "18f2905e8b784d6a9a525752e85ddede",
      "status": "SUCCESS_WITH_WARNINGS",
      "metrics": {
        "total_processed": 456114,
        "total_valid": 456114,
        "total_inserted": 456114,
        "total_updated": 0,
        "total_rejected": 0,
        "chunks_completed": 48
      },
      "reconciliation": {
        "status": "WARNING",
        "results": {
          "indicadores_conjunto": {
            "checked": 3978,
            "valid": 17,
            "invalid": 3961
          }
        }
      }
    },
    "conj": {
      "load_id": "bacba235b2e343b68d6809747ad0d8aa",
      "status": "SUCCESS",
      "metrics": {
        "total_processed": 262557,
        "total_valid": 262517,
        "total_inserted": 0,
        "total_updated": 948,
        "total_rejected": 40,
        "chunks_completed": 3
      },
      "reconciliation": null
    }
  }
}
```

IMPORTANT:

- Overall Status: SUCCESS_WITH_WARNINGS
All 4 files were processed and persisted successfully. The warning flag was raised because the continuity indicators dataset contains references to consumer unit sets that do not exist in the current geographic database.

- energy_losses_tariff — SUCCESS
631 tariff records were inserted with no issues. No reconciliation is performed for this collection as it has no cross-collection references.

- gdb — SUCCESS
61,375 geographic features were processed across all layers (CONJ, SUB, UN_TRA_D). All records were inserted successfully. No reconciliation is performed at the GDB level since it is the reference source for other collections.

- distribution_indices — SUCCESS_WITH_WARNINGS
456,114 continuity indicator records (DEC/FEC) were inserted successfully. However, the reconciliation step detected that 3,961 out of 3,978 unique consumer unit set IDs do not have a corresponding entry in the conj collection.
This is expected behavior: the indicators CSV contains data from all Brazilian distributors, while the GDB loaded covers only EDP SP. The 17 valid references correspond to the 52 EDP SP sets present in the database. Records from other distributors are stored in distribution_indices and will be linked to conj once their respective GDB files are uploaded.

- conj — SUCCESS
262,517 limit records were processed. 948 documents in conj were enriched with annual_summaries data from the limits CSV, and the distribution_indices array was populated for the EDP SP sets that matched. 40 records were rejected due to missing required fields in the source file.

---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [ ] New and existing tests pass with my changes