### PR TITLE
feat(consent): implement pending consent flow and modal for user agre…

### DIFF
--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -1,11 +1,12 @@
 import { AppRoutes } from "./routes";
 import { Toaster } from "sonner";
+import PendingConsentProvider from "@/components/consent/PendingConsentProvider";
 
 export default function App() {
   return (
-    <>
+    <PendingConsentProvider>
       <AppRoutes />
       <Toaster richColors position="top-right" />
-    </>
+    </PendingConsentProvider>
   );
 }

--- a/apps/frontend/src/api/adminClient.js
+++ b/apps/frontend/src/api/adminClient.js
@@ -1,3 +1,5 @@
+import { waitForPendingConsentAcceptance } from "./pendingConsentInterceptor";
+
 const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
 const SESSION_KEYS = [
@@ -34,7 +36,7 @@ const buildAuthHeaders = () => {
   };
 };
 
-async function request(path, options = {}) {
+async function request(path, options = {}, retryAfterConsent = true) {
   const { headers: requestHeaders, ...requestOptions } = options;
 
   const url = `${API_BASE_URL}${path}`;
@@ -59,6 +61,15 @@ async function request(path, options = {}) {
       const error = new Error(`Erro na API: ${response.status}`);
       error.status = response.status;
       error.data = responseBody;
+
+      if (retryAfterConsent) {
+        const shouldRetry = await waitForPendingConsentAcceptance(error);
+
+        if (shouldRetry) {
+          return request(path, options, false);
+        }
+      }
+
       throw error;
     }
 
@@ -68,6 +79,42 @@ async function request(path, options = {}) {
     console.error("adminClient: falha na requisição", { url, options: requestOptions, error: fetchError });
     throw fetchError;
   }
+}
+
+async function postFormRequest(path, formData, options = {}, retryAfterConsent = true) {
+  const { headers: requestHeaders, ...requestOptions } = options;
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...requestOptions,
+    method: "POST",
+    headers: {
+      ...buildAuthHeaders(),
+      ...requestHeaders,
+    },
+    body: formData,
+  });
+
+  const contentType = response.headers.get("content-type");
+  const responseBody = contentType?.includes("application/json")
+    ? await response.json()
+    : await response.text();
+
+  if (!response.ok) {
+    const error = new Error(`Erro na API: ${response.status}`);
+    error.status = response.status;
+    error.data = responseBody;
+
+    if (retryAfterConsent) {
+      const shouldRetry = await waitForPendingConsentAcceptance(error);
+      if (shouldRetry) {
+        return postFormRequest(path, formData, options, false);
+      }
+    }
+
+    throw error;
+  }
+
+  return responseBody;
 }
 
 export const adminClient = {
@@ -104,31 +151,5 @@ export const adminClient = {
       ...options,
     }),
 
-  postForm: async (path, formData, options = {}) => {
-    const { headers: requestHeaders, ...requestOptions } = options;
-
-    const response = await fetch(`${API_BASE_URL}${path}`, {
-      ...requestOptions,
-      method: "POST",
-      headers: {
-        ...buildAuthHeaders(),
-        ...requestHeaders,
-      },
-      body: formData,
-    });
-
-    const contentType = response.headers.get("content-type");
-    const responseBody = contentType?.includes("application/json")
-      ? await response.json()
-      : await response.text();
-
-    if (!response.ok) {
-      const error = new Error(`Erro na API: ${response.status}`);
-      error.status = response.status;
-      error.data = responseBody;
-      throw error;
-    }
-
-    return responseBody;
-  },
+  postForm: (path, formData, options = {}) => postFormRequest(path, formData, options),
 };

--- a/apps/frontend/src/api/client.js
+++ b/apps/frontend/src/api/client.js
@@ -1,12 +1,14 @@
+import { waitForPendingConsentAcceptance } from "./pendingConsentInterceptor";
+
 const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 
-async function request(path, options = {}) {
+async function request(path, options = {}, retryAfterConsent = true) {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: options?.method ?? "GET",
-    ...(options || {}),
+    ...options,
     headers: {
       "Content-Type": "application/json",
-      ...(options?.headers || {}),
+      ...options?.headers,
     },
   });
 
@@ -19,10 +21,56 @@ async function request(path, options = {}) {
     const error = new Error(`Erro na API: ${response.status}`);
     error.status = response.status;
     error.data = responseBody;
+
+    if (retryAfterConsent) {
+      const shouldRetry = await waitForPendingConsentAcceptance(error);
+
+      if (shouldRetry) {
+        return request(path, options, false);
+      }
+    }
+
     throw error;
   }
 
   return responseBody;
+}
+
+async function postFormRequest(path, formData, options = {}, retryAfterConsent = true) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    body: formData,
+    // Do not set Content-Type for FormData; browser will set the correct boundary
+    ...options,
+  });
+
+  if (!response.ok) {
+    const contentType = response.headers.get("content-type");
+    const responseBody = contentType?.includes("application/json")
+      ? await response.json()
+      : await response.text();
+
+    const error = new Error(`Erro na API: ${response.status}`);
+    error.status = response.status;
+    error.data = responseBody;
+
+    if (retryAfterConsent) {
+      const shouldRetry = await waitForPendingConsentAcceptance(error);
+      if (shouldRetry) {
+        return postFormRequest(path, formData, options, false);
+      }
+    }
+
+    throw error;
+  }
+
+  const contentType = response.headers.get("content-type");
+
+  if (contentType?.includes("application/json")) {
+    return response.json();
+  }
+
+  return response.text();
 }
 
 export const apiClient = {
@@ -59,24 +107,5 @@ export const apiClient = {
       ...options,
     }),
   // Send FormData (file uploads). Caller must provide a FormData instance as `body`.
-  postForm: async (path, formData, options = {}) => {
-    const response = await fetch(`${API_BASE_URL}${path}`, {
-      method: "POST",
-      body: formData,
-      // Do not set Content-Type for FormData; browser will set the correct boundary
-      ...(options || {}),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Erro na API: ${response.status}`);
-    }
-
-    const contentType = response.headers.get("content-type");
-
-    if (contentType && contentType.includes("application/json")) {
-      return response.json();
-    }
-
-    return response.text();
-  },
+  postForm: (path, formData, options = {}) => postFormRequest(path, formData, options),
 };

--- a/apps/frontend/src/api/pendingConsentInterceptor.js
+++ b/apps/frontend/src/api/pendingConsentInterceptor.js
@@ -1,0 +1,43 @@
+let pendingConsentHandler = null;
+
+export function registerPendingConsentHandler(handler) {
+  pendingConsentHandler = handler;
+
+  return () => {
+    if (pendingConsentHandler === handler) {
+      pendingConsentHandler = null;
+    }
+  };
+}
+
+export function isPendingConsentError(error) {
+  if (error?.status !== 403) {
+    return false;
+  }
+
+  const data = error.data;
+  const detail = data?.detail;
+
+  if (detail === "pending_consent") {
+    return true;
+  }
+
+  if (detail && typeof detail === "object" && detail.code === "pending_consent") {
+    return true;
+  }
+
+  return data?.code === "pending_consent";
+}
+
+export async function waitForPendingConsentAcceptance(error) {
+  if (!isPendingConsentError(error)) {
+    return false;
+  }
+
+  if (!pendingConsentHandler) {
+    throw error;
+  }
+
+  await pendingConsentHandler();
+  return true;
+}

--- a/apps/frontend/src/components/consent/ConsentFlowStep.jsx
+++ b/apps/frontend/src/components/consent/ConsentFlowStep.jsx
@@ -1,0 +1,231 @@
+import { AlertTriangle, ChevronDown, Loader2, ShieldCheck } from "lucide-react";
+import PropTypes from "prop-types";
+import { Button } from "@/components/ui/button";
+
+function formatPolicyType(policyType) {
+  if (policyType === "TERMS_OF_USE") return "Termos de Uso";
+  if (policyType === "PRIVACY_POLICY") return "Política de Privacidade";
+
+  return String(policyType || "Documento").replaceAll("_", " ");
+}
+
+export default function ConsentFlowStep({
+  terms,
+  pendingClauseIds,
+  selectedClauseIds,
+  expandedVersionIds,
+  allClauses,
+  allClausesAccepted,
+  loadingTerms,
+  loadError,
+  submittingConsent,
+  onBack,
+  onRetry,
+  onToggleClause,
+  onToggleVersion,
+  onSubmit,
+  submitLabel,
+}) {
+  let termsSection = null;
+
+  if (loadingTerms) {
+    termsSection = (
+      <div className="flex items-center justify-center gap-2 rounded-xl border border-border bg-card p-6 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" />
+        <span>Carregando termos...</span>
+      </div>
+    );
+  } else if (loadError) {
+    termsSection = (
+      <div className="rounded-xl border border-destructive/20 bg-destructive/10 p-4 text-sm text-destructive">
+        <p>{loadError}</p>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onRetry}
+          className="mt-3 border-destructive/20 text-destructive hover:bg-destructive/10"
+        >
+          Tentar novamente
+        </Button>
+      </div>
+    );
+  } else if (allClauses.length === 0) {
+    termsSection = (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+        Não há cláusulas ativas para aceitar no momento.
+      </div>
+    );
+  } else {
+    termsSection = (
+      <div className="space-y-3">
+        {terms.map((policyVersion) => {
+          const versionId = String(policyVersion.policy_version_id);
+          const versionClauses = policyVersion.clauses || [];
+          const isExpanded = expandedVersionIds.has(versionId);
+
+          return (
+            <section key={versionId} className="overflow-hidden rounded-xl border border-border bg-card">
+              <button
+                type="button"
+                onClick={() => onToggleVersion(versionId)}
+                className="flex w-full items-center justify-between gap-4 border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/50"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {formatPolicyType(policyVersion.policy_type)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Versão {policyVersion.version} · {versionClauses.length} cláusulas
+                  </p>
+                </div>
+
+                <ChevronDown
+                  className={`h-4 w-4 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
+                />
+              </button>
+
+              {isExpanded && (
+                <div className="space-y-4 p-4">
+                  {policyVersion.content && (
+                    <div className="whitespace-pre-line rounded-lg bg-muted/40 p-3 text-sm leading-6 text-muted-foreground">
+                      {policyVersion.content}
+                    </div>
+                  )}
+
+                  <div className="space-y-3">
+                    {versionClauses.map((clause) => {
+                      const clauseId = String(clause.clause_uuid);
+                      const checked = selectedClauseIds.has(clauseId);
+                      const isPending = pendingClauseIds.has(clauseId);
+                      const checkboxId = `clause-${clauseId}`;
+
+                      return (
+                        <div
+                          key={clauseId}
+                          className={`flex gap-3 rounded-lg border p-4 transition-colors ${
+                            checked ? "border-primary/40 bg-primary/5" : "border-border hover:bg-muted/40"
+                          }`}
+                        >
+                          <input
+                            id={checkboxId}
+                            type="checkbox"
+                            className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                            checked={checked}
+                            onChange={() => onToggleClause(clauseId)}
+                          />
+
+                          <div className="min-w-0 flex-1">
+                            <label htmlFor={checkboxId} className="cursor-pointer">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <span className="text-sm font-semibold text-foreground">{clause.title}</span>
+                                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                                  {clause.mandatory ? "Obrigatória" : "Opcional"}
+                                </span>
+                                {isPending && (
+                                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+                                    Pendente
+                                  </span>
+                                )}
+                              </div>
+                            </label>
+
+                            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                              {clause.description || "Sem descrição informada."}
+                            </p>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-3 rounded-xl border border-border bg-card p-4">
+        <div className="rounded-full bg-primary/10 p-2">
+          <ShieldCheck className="h-5 w-5 text-primary" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold text-foreground">Aceite os termos</h2>
+            {allClausesAccepted ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                <span className="inline-block h-3.5 w-3.5 rounded-full bg-green-600" aria-hidden="true" />
+                <span className="ml-1">Tudo aceito</span>
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                Pendente
+              </span>
+            )}
+          </div>
+
+          <p className="mt-1 text-sm text-muted-foreground">
+            Leia os documentos ativos e marque as caixas para concluir o cadastro.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">Progresso:</span> {selectedClauseIds.size}/{allClauses.length} cláusulas aceitas
+      </div>
+
+      {termsSection}
+
+      <div className="flex flex-col-reverse gap-3 border-t border-border pt-6 sm:flex-row sm:justify-end">
+        {onBack ? (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onBack}
+            className="border-border text-foreground hover:bg-muted"
+            disabled={submittingConsent}
+          >
+            Voltar
+          </Button>
+        ) : null}
+
+        <Button
+          type="button"
+          onClick={onSubmit}
+          className="bg-primary text-primary-foreground hover:bg-primary/90"
+          disabled={!allClausesAccepted || loadingTerms || submittingConsent || Boolean(loadError)}
+        >
+          {submittingConsent ? "Finalizando..." : submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+ConsentFlowStep.propTypes = {
+  terms: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  pendingClauseIds: PropTypes.instanceOf(Set).isRequired,
+  selectedClauseIds: PropTypes.instanceOf(Set).isRequired,
+  expandedVersionIds: PropTypes.instanceOf(Set).isRequired,
+  allClauses: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  allClausesAccepted: PropTypes.bool.isRequired,
+  loadingTerms: PropTypes.bool.isRequired,
+  loadError: PropTypes.string.isRequired,
+  submittingConsent: PropTypes.bool.isRequired,
+  onBack: PropTypes.func,
+  onRetry: PropTypes.func.isRequired,
+  onToggleClause: PropTypes.func.isRequired,
+  onToggleVersion: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  submitLabel: PropTypes.string,
+};
+
+ConsentFlowStep.defaultProps = {
+  onBack: undefined,
+  submitLabel: "Concluir Cadastro",
+};

--- a/apps/frontend/src/components/consent/PendingConsentProvider.jsx
+++ b/apps/frontend/src/components/consent/PendingConsentProvider.jsx
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { toast } from "sonner";
+
+import { getTerms } from "@/api/terms";
+import { getPendingConsent, submitConsent } from "@/api/consent";
+import { registerPendingConsentHandler } from "@/api/pendingConsentInterceptor";
+import ConsentFlowStep from "@/components/consent/ConsentFlowStep";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+function flattenTerms(terms) {
+  return terms.flatMap((policyVersion) =>
+    (policyVersion.clauses || []).map((clause) => ({
+      ...clause,
+      policy_version_id: policyVersion.policy_version_id,
+      policy_type: policyVersion.policy_type,
+      version: policyVersion.version,
+      content: policyVersion.content,
+    })),
+  );
+}
+
+function buildConsentActions(terms, selectedClauseIds) {
+  return flattenTerms(terms)
+    .filter((clause) => selectedClauseIds.has(String(clause.clause_uuid)))
+    .map((clause) => ({
+      clause_uuid: clause.clause_uuid,
+      policy_version_id: clause.policy_version_id,
+      action: "CONSENT",
+    }));
+}
+
+export default function PendingConsentProvider({ children }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [terms, setTerms] = useState([]);
+  const [pendingClauses, setPendingClauses] = useState([]);
+  const [selectedClauseIds, setSelectedClauseIds] = useState(() => new Set());
+  const [expandedVersionIds, setExpandedVersionIds] = useState(() => new Set());
+  const [loadingTerms, setLoadingTerms] = useState(false);
+  const [loadError, setLoadError] = useState("");
+  const [submittingConsent, setSubmittingConsent] = useState(false);
+  const [submissionError, setSubmissionError] = useState("");
+
+  const pendingPromiseRef = useRef(null);
+  const pendingResolveRef = useRef(null);
+  const pendingRejectRef = useRef(null);
+
+  const allClauses = useMemo(() => flattenTerms(terms), [terms]);
+  const pendingClauseIds = useMemo(
+    () => new Set(pendingClauses.map((clause) => String(clause.clause_uuid))),
+    [pendingClauses],
+  );
+  const allClausesAccepted =
+    allClauses.length > 0 &&
+    allClauses
+      .filter((clause) => clause.mandatory)
+      .every((clause) => selectedClauseIds.has(String(clause.clause_uuid)));
+
+  const fetchTermsAndConsentData = useCallback(async () => {
+    try {
+      setLoadingTerms(true);
+      setLoadError("");
+      setSubmissionError("");
+
+      const [termsResponse, pendingResponse] = await Promise.all([
+        getTerms(),
+        getPendingConsent().catch(() => ({ pending_clauses: [] })),
+      ]);
+
+      const nextTerms = termsResponse.terms || [];
+      setTerms(nextTerms);
+      setPendingClauses(pendingResponse.pending_clauses || []);
+
+      if (nextTerms.length > 0) {
+        setExpandedVersionIds(new Set([String(nextTerms[0].policy_version_id)]));
+      }
+    } catch {
+      setLoadError("Não foi possível carregar os termos.");
+    } finally {
+      setLoadingTerms(false);
+    }
+  }, []);
+
+  const openPendingConsentModal = useCallback(async () => {
+    if (pendingPromiseRef.current) {
+      return pendingPromiseRef.current;
+    }
+
+    setSelectedClauseIds(new Set());
+    setExpandedVersionIds(new Set());
+    setSubmissionError("");
+    setIsOpen(true);
+
+    fetchTermsAndConsentData();
+
+    const pendingPromise = new Promise((resolve, reject) => {
+      pendingResolveRef.current = resolve;
+      pendingRejectRef.current = reject;
+    }).finally(() => {
+      pendingPromiseRef.current = null;
+      pendingResolveRef.current = null;
+      pendingRejectRef.current = null;
+    });
+
+    pendingPromiseRef.current = pendingPromise;
+    return pendingPromise;
+  }, [fetchTermsAndConsentData]);
+
+  useEffect(() => {
+    const unregister = registerPendingConsentHandler(openPendingConsentModal);
+
+    return () => {
+      unregister();
+    };
+  }, [openPendingConsentModal]);
+
+  useEffect(() => {
+    return () => {
+      if (pendingRejectRef.current) {
+        pendingRejectRef.current(new Error("pending_consent_unmounted"));
+      }
+    };
+  }, []);
+
+  function toggleClause(clauseUuid) {
+    setSelectedClauseIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(clauseUuid)) {
+        next.delete(clauseUuid);
+      } else {
+        next.add(clauseUuid);
+      }
+
+      return next;
+    });
+  }
+
+  function toggleVersion(versionId) {
+    setExpandedVersionIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(versionId)) {
+        next.delete(versionId);
+      } else {
+        next.add(versionId);
+      }
+
+      return next;
+    });
+  }
+
+  async function handleSubmit() {
+    if (!allClausesAccepted || loadingTerms || submittingConsent || loadError) {
+      return;
+    }
+
+    try {
+      setSubmittingConsent(true);
+      setSubmissionError("");
+
+      const actions = buildConsentActions(terms, selectedClauseIds);
+      await submitConsent(actions);
+
+      setIsOpen(false);
+      pendingResolveRef.current?.();
+      toast.success("Termos aceitos com sucesso.");
+    } catch {
+      setSubmissionError("Não foi possível concluir o consentimento.");
+      toast.error("Não foi possível concluir o consentimento.");
+    } finally {
+      setSubmittingConsent(false);
+    }
+  }
+
+  return (
+    <>
+      {children}
+
+      {isOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/90 p-4 backdrop-blur-sm">
+          <Card className="max-h-[90vh] w-full max-w-3xl overflow-y-auto border-border bg-card">
+            <CardHeader>
+              <CardTitle>Consentimento pendente</CardTitle>
+              <CardDescription>
+                Sua sessão continua ativa. Aceite os termos pendentes para seguir no sistema.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              {submissionError ? (
+                <div className="rounded-xl border border-destructive/20 bg-destructive/10 p-4 text-sm text-destructive">
+                  {submissionError}
+                </div>
+              ) : null}
+
+              <ConsentFlowStep
+                terms={terms}
+                pendingClauseIds={pendingClauseIds}
+                selectedClauseIds={selectedClauseIds}
+                expandedVersionIds={expandedVersionIds}
+                allClauses={allClauses}
+                allClausesAccepted={allClausesAccepted}
+                loadingTerms={loadingTerms}
+                loadError={loadError}
+                submittingConsent={submittingConsent}
+                onRetry={fetchTermsAndConsentData}
+                onToggleClause={toggleClause}
+                onToggleVersion={toggleVersion}
+                onSubmit={handleSubmit}
+                submitLabel="Aceitar termos"
+              />
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+PendingConsentProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/apps/frontend/src/pages/login/ConsentPage.jsx
+++ b/apps/frontend/src/pages/login/ConsentPage.jsx
@@ -104,7 +104,9 @@ export default function ConsentPage() {
   )
   const allClausesAccepted =
     allClauses.length > 0 &&
-    allClauses.every((clause) => selectedClauseIds.has(String(clause.clause_uuid)))
+    allClauses
+      .filter((clause) => clause.mandatory)
+      .every((clause) => selectedClauseIds.has(String(clause.clause_uuid)))
 
   useEffect(() => {
     if (terms.length === 0) {

--- a/apps/frontend/src/pages/login/PrimeiroAcessoPage.jsx
+++ b/apps/frontend/src/pages/login/PrimeiroAcessoPage.jsx
@@ -2,14 +2,9 @@ import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import {
   AlertCircle,
-  AlertTriangle,
   Check,
-  CheckCircle2,
-  ChevronDown,
   Eye,
   EyeOff,
-  Loader2,
-  ShieldCheck,
   Zap,
 } from "lucide-react"
 import PropTypes from "prop-types"
@@ -18,6 +13,7 @@ import { toast } from "sonner"
 import { firstAccess } from "@/api/auth"
 import { getPendingConsent, submitConsent } from "@/api/consent"
 import { getTerms } from "@/api/terms"
+import ConsentFlowStep from "@/components/consent/ConsentFlowStep"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -32,13 +28,6 @@ function flattenTerms(terms) {
       content: policyVersion.content,
     })),
   )
-}
-
-function formatPolicyType(policyType) {
-  if (policyType === "TERMS_OF_USE") return "Termos de Uso"
-  if (policyType === "PRIVACY_POLICY") return "Política de Privacidade"
-
-  return String(policyType || "Documento").replaceAll("_", " ")
 }
 
 function buildConsentActions(terms, selectedClauseIds) {
@@ -181,222 +170,6 @@ PasswordStep.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   submitting: PropTypes.bool.isRequired,
   tokenMissing: PropTypes.bool.isRequired,
-}
-
-function ConsentStep({
-  terms,
-  pendingClauseIds,
-  selectedClauseIds,
-  expandedVersionIds,
-  allClauses,
-  allClausesAccepted,
-  consentToken,
-  loadingTerms,
-  loadError,
-  submittingConsent,
-  onBack,
-  onRetry,
-  onToggleClause,
-  onToggleVersion,
-  onSubmit,
-}) {
-  let termsSection = null
-
-  if (loadingTerms) {
-    termsSection = (
-      <div className="flex items-center justify-center gap-2 rounded-xl border border-border bg-card p-6 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin" />
-        <span>Carregando termos...</span>
-      </div>
-    )
-  } else if (loadError) {
-    termsSection = (
-      <div className="rounded-xl border border-destructive/20 bg-destructive/10 p-4 text-sm text-destructive">
-        <p>{loadError}</p>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onRetry}
-          className="mt-3 border-destructive/20 text-destructive hover:bg-destructive/10"
-        >
-          Tentar novamente
-        </Button>
-      </div>
-    )
-  } else if (allClauses.length === 0) {
-    termsSection = (
-      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
-        Não há cláusulas ativas para aceitar no momento.
-      </div>
-    )
-  } else {
-    termsSection = (
-      <div className="space-y-3">
-        {terms.map((policyVersion) => {
-          const versionId = String(policyVersion.policy_version_id)
-          const versionClauses = policyVersion.clauses || []
-          const isExpanded = expandedVersionIds.has(versionId)
-
-          return (
-            <section key={versionId} className="overflow-hidden rounded-xl border border-border bg-card">
-              <button
-                type="button"
-                onClick={() => onToggleVersion(versionId)}
-                className="flex w-full items-center justify-between gap-4 border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/50"
-              >
-                <div>
-                  <p className="text-sm font-semibold text-foreground">
-                    {formatPolicyType(policyVersion.policy_type)}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Versão {policyVersion.version} · {versionClauses.length} cláusulas
-                  </p>
-                </div>
-
-                <ChevronDown
-                  className={`h-4 w-4 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
-                />
-              </button>
-
-              {isExpanded && (
-                <div className="space-y-4 p-4">
-                  {policyVersion.content && (
-                    <div className="whitespace-pre-line rounded-lg bg-muted/40 p-3 text-sm leading-6 text-muted-foreground">
-                      {policyVersion.content}
-                    </div>
-                  )}
-
-                  <div className="space-y-3">
-                    {versionClauses.map((clause) => {
-                      const clauseId = String(clause.clause_uuid)
-                      const checked = selectedClauseIds.has(clauseId)
-                      const isPending = pendingClauseIds.has(clauseId)
-                      const checkboxId = `clause-${clauseId}`
-
-                      return (
-                        <div
-                          key={clauseId}
-                          className={`flex gap-3 rounded-lg border p-4 transition-colors ${
-                            checked ? "border-primary/40 bg-primary/5" : "border-border hover:bg-muted/40"
-                          }`}
-                        >
-                          <input
-                            id={checkboxId}
-                            type="checkbox"
-                            className="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary"
-                            checked={checked}
-                            onChange={() => onToggleClause(clauseId)}
-                          />
-
-                          <div className="min-w-0 flex-1">
-                            <label htmlFor={checkboxId} className="cursor-pointer">
-                              <div className="flex flex-wrap items-center gap-2">
-                                <span className="text-sm font-semibold text-foreground">
-                                  {clause.title}
-                                </span>
-                                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                                  {clause.mandatory ? "Obrigatória" : "Opcional"}
-                                </span>
-                                {isPending && (
-                                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
-                                    Pendente
-                                  </span>
-                                )}
-                              </div>
-                            </label>
-
-                            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-                              {clause.description || "Sem descrição informada."}
-                            </p>
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
-              )}
-            </section>
-          )
-        })}
-      </div>
-    )
-  }
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-start gap-3 rounded-xl border border-border bg-card p-4">
-        <div className="rounded-full bg-primary/10 p-2">
-          <ShieldCheck className="h-5 w-5 text-primary" />
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-base font-semibold text-foreground">Aceite os termos</h2>
-            {allClausesAccepted ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
-                <CheckCircle2 className="h-3.5 w-3.5" />
-                Tudo aceito
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
-                <AlertTriangle className="h-3.5 w-3.5" />
-                Pendente
-              </span>
-            )}
-          </div>
-
-          <p className="mt-1 text-sm text-muted-foreground">
-            Leia os documentos ativos e marque as caixas para concluir o cadastro.
-          </p>
-        </div>
-      </div>
-
-      <div className="rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
-        <span className="font-medium text-foreground">Progresso:</span> {selectedClauseIds.size}/{allClauses.length} cláusulas aceitas
-      </div>
-
-      {termsSection}
-
-      <div className="flex flex-col-reverse gap-3 border-t border-border pt-6 sm:flex-row sm:justify-end">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onBack}
-          className="border-border text-foreground hover:bg-muted"
-          disabled={submittingConsent}
-        >
-          Voltar
-        </Button>
-
-        <Button
-          type="button"
-          onClick={onSubmit}
-          className="bg-primary text-primary-foreground hover:bg-primary/90"
-          disabled={!allClausesAccepted || loadingTerms || submittingConsent || Boolean(loadError) || !consentToken}
-        >
-          {submittingConsent ? "Finalizando..." : "Concluir Cadastro"}
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-ConsentStep.propTypes = {
-  terms: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  pendingClauseIds: PropTypes.instanceOf(Set).isRequired,
-  selectedClauseIds: PropTypes.instanceOf(Set).isRequired,
-  expandedVersionIds: PropTypes.instanceOf(Set).isRequired,
-  allClauses: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  allClausesAccepted: PropTypes.bool.isRequired,
-  consentToken: PropTypes.string.isRequired,
-  loadingTerms: PropTypes.bool.isRequired,
-  loadError: PropTypes.string.isRequired,
-  submittingConsent: PropTypes.bool.isRequired,
-  onBack: PropTypes.func.isRequired,
-  onRetry: PropTypes.func.isRequired,
-  onToggleClause: PropTypes.func.isRequired,
-  onToggleVersion: PropTypes.func.isRequired,
-  onSubmit: PropTypes.func.isRequired,
 }
 
 export default function PrimeiroAcessoPage() {
@@ -632,14 +405,13 @@ export default function PrimeiroAcessoPage() {
               tokenMissing={tokenMissing}
             />
           ) : (
-            <ConsentStep
+            <ConsentFlowStep
               terms={terms}
               pendingClauseIds={pendingClauseIds}
               selectedClauseIds={selectedClauseIds}
               expandedVersionIds={expandedVersionIds}
               allClauses={allClauses}
               allClausesAccepted={allClausesAccepted}
-              consentToken={consentToken}
               loadingTerms={loadingTerms}
               loadError={loadError}
               submittingConsent={submittingConsent}
@@ -648,6 +420,7 @@ export default function PrimeiroAcessoPage() {
               onToggleClause={toggleClause}
               onToggleVersion={toggleVersion}
               onSubmit={handleFinalSubmit}
+              submitLabel="Concluir Cadastro"
             />
           )}
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #331

---

## 📝 What was done?
- Fixed a bug in the terms acceptance logic: previously, the confirm button remained disabled if any clause was unchecked, including optional ones.
  - The button is now disabled only when one or more **required** clauses are not accepted.
  - Optional clauses do not block submission.

---

## 🧪 How to test locally

```bash
# 1. Build and start the environment
docker compose --profile full up --build

# 2. Log in with the default admin account
#    Email:    admin@admin.com
#    Password: Admin@123

# 3. Create a new user and a new term with one or more clauses (at least one optional)
#    Use the User Management and Terms Management screens in the application
```

```powershell
# 4. In PowerShell, generate the raw token and its SHA-256 hash
$rawToken = ([guid]::NewGuid().ToString("N") + [guid]::NewGuid().ToString("N")); $sha = [System.Security.Cryptography.SHA256]::Create(); $hash = ($sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($rawToken)) | ForEach-Object { $_.ToString("x2") }) -join ""; Write-Host "RAW TOKEN:" $rawToken; Write-Host "HASH:" $hash
```

```bash
# 5. Enter the postgres container
docker compose exec postgres bash

# 6. Enter psql
psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"
```

```sql
-- 7. Force first access as pending for the new user
UPDATE tb_user
SET first_access_completed = FALSE,
    updated_at = NOW()
WHERE username = 'YOUR_USERNAME';

-- 8. Insert the first access token (replace with the HASH generated in step 4)
INSERT INTO tb_first_access_token (user_id, token_hash, expires_at, used_at)
VALUES (
    (SELECT user_uuid FROM tb_user WHERE username = 'YOUR_USERNAME'),
    'PASTE_HASH_HERE',
    NOW() + INTERVAL '1 day',
    NULL
);
```

```
# 9. Complete first access for the new user
- Open http://localhost:5173/first-access?token=YOUR_RAW_TOKEN_HERE
- On the terms step, accept only the required clauses and leave optional ones unchecked
- Confirm the submit button is enabled and the flow completes successfully

# 10. Validate the blocking modal with the admin account
- Log out and log in as admin
- Wait for the new term to become active (or trigger it manually via the database)
- Perform any action that triggers an API request
- Confirm the blocking modal appears without ending the session
- Accept only the required clauses and confirm
- Confirm the original request is reprocessed and the user remains on the same page
```

---

## ⚠️ Risks and Potential Impact
- If the terms endpoint is unavailable, the modal will fail to load and the user will remain blocked.

---

## 📸 Evidence

### Consent Screen
<img width="1879" height="922" alt="image" src="https://github.com/user-attachments/assets/2e5fce0d-3fd2-4472-b48e-c3b0330363cc" />

### First Access Screen
<img width="1875" height="923" alt="image" src="https://github.com/user-attachments/assets/c6370026-fa34-4d3c-9aff-c7d23c4dcbbb" />


---

## ✅ Definition of Done
- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist
- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [ ] I added comments for complex or non-obvious code
- [ ] Documentation updated if needed
- [x] My changes do not generate new warnings
- [ ] New and existing tests pass with my changes