### PR TITLE
Feature/201 create an endpoint to trigger the pipeline

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -20,6 +20,7 @@ from src.api.routes import auth
 from src.api.routes import consent
 from src.api.routes import terms
 from src.api.routes import admin_terms
+from src.api.routes import predictions
 
 from src.config.lifespan import lifespan
 
@@ -34,6 +35,7 @@ app.include_router(upload.router)
 app.include_router(gdb.router)
 app.include_router(tam_sam.router)
 app.include_router(timeseries.router)
+app.include_router(predictions.router)
 app.include_router(users.router)
 app.include_router(auth.router)
 app.include_router(consent.router)

--- a/apps/backend/src/api/routes/predictions.py
+++ b/apps/backend/src/api/routes/predictions.py
@@ -1,0 +1,339 @@
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from typing import Optional, List
+from datetime import datetime, timezone
+import logging
+import uuid
+
+from src.control.timeseries_forecast_procedures import TimeSeriesForecastProcedures
+from src.etl.load.load_predictions import persist_predictions
+from src.model.prediction_model import Prediction
+from src.config.settings import Settings
+from src.database.connection import get_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/predictions", tags=["predictions"])
+
+
+def get_all_consumer_units() -> List[str]:
+    """
+    Query MongoDB for all unique consumer_unit_set_id values in distribution_indices collection.
+    
+    Returns:
+        List of unique consumer unit IDs, or empty list if none found.
+    """
+    try:
+        settings = Settings()
+        client = get_client()
+        db = client[settings.mongo_db_name]
+        collection = db["distribution_indices"]
+        
+        units = collection.distinct("consumer_unit_set_id")
+        logger.info(f"[get_all_consumer_units] Found {len(units)} unique consumer units")
+        return units
+    except Exception as exc:
+        logger.exception("[get_all_consumer_units] Error querying consumer units: %s", exc)
+        return []
+
+
+def generate_predictions_task(
+    consumer_unit_set_id: Optional[str] = None,
+    indicator_types: Optional[List[str]] = None,
+    year_start: int = 2015,
+    year_end: int = 2024,
+) -> None:
+    """
+    Background task to generate and persist predictions for consumer units.
+    
+    If consumer_unit_set_id is None, forecasts all unique units in the database.
+    If specified, forecasts only that unit.
+    
+    Args:
+        consumer_unit_set_id: Specific unit to forecast, or None for all units
+        indicator_types: List of indicators ("DEC", "FEC"), defaults to both
+        year_start: Start year for training data
+        year_end: End year for training data
+    """
+    if indicator_types is None:
+        indicator_types = ["DEC", "FEC"]
+    
+    try:
+        settings = Settings()
+        client = get_client()
+        db = client[settings.mongo_db_name]
+        predictions_collection = db["predictions"]
+        
+        # Determine which units to forecast
+        units_to_process = []
+        if consumer_unit_set_id:
+            units_to_process = [consumer_unit_set_id]
+        else:
+            units_to_process = get_all_consumer_units()
+        
+        if not units_to_process:
+            logger.warning("[generate_predictions_task] No consumer units found to forecast")
+            return
+        
+        logger.info(f"[generate_predictions_task] Starting forecast for {len(units_to_process)} units")
+        
+        procedures = TimeSeriesForecastProcedures(connection=client)
+        total_inserted = 0
+        total_updated = 0
+        failed_units = []
+        
+        # Process each unit
+        for unit_id in units_to_process:
+            try:
+                logger.info(f"[generate_predictions_task] Forecasting unit {unit_id}")
+                
+                result = procedures.forecast_for_unit(
+                    consumer_unit_set_id=unit_id,
+                    year_start=year_start,
+                    year_end=year_end,
+                    indicator_types=indicator_types,
+                    save_models=True,
+                )
+                
+                if not result.get("success"):
+                    logger.warning(
+                        f"[generate_predictions_task] Forecast failed for {unit_id}: {result.get('message')}"
+                    )
+                    failed_units.append(unit_id)
+                    continue
+                
+                # Persist predictions
+                all_predictions = []
+                for forecast in result.get("forecasts", []):
+                    pred = {
+                        "consumer_unit_set_id": forecast.get("consumer_unit_id"),
+                        "indicator": forecast.get("indicator"),
+                        "forecast_year": forecast.get("forecast_year"),
+                        "forecast_period": forecast.get("forecast_period"),
+                        "forecast_value": forecast.get("forecast_value"),
+                        "model": "RandomForestRegressor",
+                        "generated_on": datetime.now(timezone.utc),
+                    }
+                    all_predictions.append(pred)
+                
+                if all_predictions:
+                    persist_metrics = persist_predictions(predictions_collection, all_predictions)
+                    total_inserted += persist_metrics.get("inserted", 0)
+                    total_updated += persist_metrics.get("updated", 0)
+                    logger.info(
+                        f"[generate_predictions_task] Unit {unit_id}: "
+                        f"Inserted {persist_metrics.get('inserted', 0)}, "
+                        f"Updated {persist_metrics.get('updated', 0)}"
+                    )
+                
+            except Exception as exc:
+                logger.exception(f"[generate_predictions_task] Error forecasting unit {unit_id}: %s", exc)
+                failed_units.append(unit_id)
+        
+        logger.info(
+            f"[generate_predictions_task] Completed. "
+            f"Total inserted: {total_inserted}, updated: {total_updated}, "
+            f"failed units: {len(failed_units)}"
+        )
+        
+        if failed_units:
+            logger.warning(f"[generate_predictions_task] Failed units: {failed_units}")
+    
+    except Exception as exc:
+        logger.exception("[generate_predictions_task] Background task failed: %s", exc)
+
+
+@router.post("/generate", status_code=202)
+async def generate_predictions(
+    background_tasks: BackgroundTasks,
+    consumer_unit_set_id: Optional[str] = Query(
+        None,
+        description="Specific consumer unit ID to forecast (e.g., '16648'). If None, forecasts all units."
+    ),
+    indicator_types: Optional[List[str]] = Query(
+        None,
+        description="Indicator types to forecast: 'DEC', 'FEC', or both. Defaults to both."
+    ),
+    year_start: int = Query(2015, description="Start year for training data"),
+    year_end: int = Query(2024, description="End year for training data"),
+):
+    """
+    Trigger prediction generation and persistence in the background.
+    
+    This endpoint accepts optional filtering parameters and schedules a background task
+    to generate and persist predictions. Returns immediately with a job_id.
+    
+    **Parameters:**
+    - `consumer_unit_set_id` (optional): Forecast only this consumer unit. If omitted, forecasts all units.
+    - `indicator_types` (optional): List of indicators to forecast (default: ["DEC", "FEC"])
+    - `year_start` (optional): Start year for training data (default: 2015)
+    - `year_end` (optional): End year for training data (default: 2024)
+    
+    **Response (HTTP 202 Accepted):**
+    ```json
+    {
+        "status": "STARTED",
+        "job_id": "<uuid>",
+        "consumer_unit_set_id": "16648 or null",
+        "indicator_types": ["DEC", "FEC"],
+        "year_range": "2015-2024"
+    }
+    ```
+    
+    **Note:** The job runs asynchronously in the background. Check the GET /predictions endpoint
+    to query saved predictions and verify results.
+    """
+    try:
+        # Normalize and validate indicator types
+        if indicator_types is None:
+            indicator_types = ["DEC", "FEC"]
+        
+        valid_indicators = {"DEC", "FEC"}
+        invalid = set(indicator_types) - valid_indicators
+        if invalid:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid indicator types: {invalid}. Valid options: {valid_indicators}"
+            )
+        
+        # Generate job ID
+        job_id = uuid.uuid4().hex
+        
+        # Schedule background task
+        background_tasks.add_task(
+            generate_predictions_task,
+            consumer_unit_set_id=consumer_unit_set_id,
+            indicator_types=indicator_types,
+            year_start=year_start,
+            year_end=year_end,
+        )
+        
+        logger.info(
+            f"[generate_predictions] Forecast scheduled - job_id: {job_id}, "
+            f"unit: {consumer_unit_set_id or 'all'}, "
+            f"indicators: {indicator_types}"
+        )
+        
+        return {
+            "status": "STARTED",
+            "job_id": job_id,
+            "consumer_unit_set_id": consumer_unit_set_id,
+            "indicator_types": indicator_types,
+            "year_range": f"{year_start}-{year_end}",
+        }
+    
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("[generate_predictions] Error: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail="Internal server error while scheduling prediction generation"
+        )
+
+
+@router.get("/", response_model=dict)
+async def get_predictions(
+    consumer_unit_set_id: Optional[str] = Query(
+        None,
+        description="Filter by consumer unit ID (e.g., '16648')"
+    ),
+    indicator: Optional[str] = Query(
+        None,
+        description="Filter by indicator type: 'DEC' or 'FEC'"
+    ),
+    skip: int = Query(0, ge=0, description="Number of records to skip (pagination)"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum records to return (default: 100, max: 1000)"),
+):
+    """
+    Query saved predictions from the database with optional filtering.
+    
+    Returns predictions with optional filters by consumer unit and indicator type.
+    Results are sorted by generation date (newest first) and paginated.
+    
+    **Parameters:**
+    - `consumer_unit_set_id` (optional): Filter by consumer unit ID
+    - `indicator` (optional): Filter by indicator type ('DEC' or 'FEC')
+    - `skip` (optional): Pagination offset (default: 0)
+    - `limit` (optional): Pagination limit (default: 100, max: 1000)
+    
+    **Response:**
+    ```json
+    {
+        "total": 150,
+        "skip": 0,
+        "limit": 100,
+        "predictions": [
+            {
+                "consumer_unit_set_id": "16648",
+                "indicator": "DEC",
+                "forecast_year": 2025,
+                "forecast_period": 1,
+                "forecast_value": 1.234,
+                "model": "RandomForestRegressor",
+                "generated_on": "2025-01-03T10:30:00Z"
+            },
+            ...
+        ]
+    }
+    ```
+    
+    **Query Examples:**
+    - Get all predictions: `GET /predictions/`
+    - Filter by unit: `GET /predictions/?consumer_unit_set_id=16648`
+    - Filter by unit and indicator: `GET /predictions/?consumer_unit_set_id=16648&indicator=DEC`
+    - Pagination: `GET /predictions/?skip=100&limit=50`
+    """
+    try:
+        settings = Settings()
+        client = get_client()
+        db = client[settings.mongo_db_name]
+        predictions_collection = db["predictions"]
+        
+        # Build filter dict (only include non-None values)
+        filter_dict = {}
+        if consumer_unit_set_id is not None:
+            filter_dict["consumer_unit_set_id"] = consumer_unit_set_id
+        if indicator is not None:
+            filter_dict["indicator"] = indicator
+        
+        # Query with pagination
+        cursor = predictions_collection.find(filter_dict).sort(
+            "generated_on", -1  # Sort by generated_on descending (newest first)
+        ).skip(skip).limit(limit)
+        
+        # Convert to list and count total
+        predictions_list = list(cursor)
+        
+        # Get total count (with filter but without pagination)
+        total_count = predictions_collection.count_documents(filter_dict)
+        
+        # Convert MongoDB documents to Pydantic models
+        predictions = []
+        for doc in predictions_list:
+            # Remove MongoDB's _id field for cleaner response
+            if "_id" in doc:
+                del doc["_id"]
+            try:
+                predictions.append(Prediction(**doc))
+            except Exception as exc:
+                logger.warning(f"[get_predictions] Failed to parse prediction document: {exc}")
+                continue
+        
+        logger.info(
+            f"[get_predictions] Returned {len(predictions)} predictions "
+            f"(total: {total_count}, filters: {filter_dict})"
+        )
+        
+        return {
+            "total": total_count,
+            "skip": skip,
+            "limit": limit,
+            "predictions": predictions,
+        }
+    
+    except Exception as exc:
+        logger.exception("[get_predictions] Error: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail="Internal server error while querying predictions"
+        )

--- a/apps/backend/src/api/routes/timeseries.py
+++ b/apps/backend/src/api/routes/timeseries.py
@@ -1,16 +1,9 @@
-"""
-Time Series Forecasting API endpoints.
-
-Routes for training RandomForest models and generating forecasts for distribution indicators.
-"""
-
 from fastapi import APIRouter, HTTPException, Query
 from typing import Optional
 from datetime import datetime, timezone
 import logging
 
 from src.control.timeseries_forecast_procedures import TimeSeriesForecastProcedures
-from src.etl.query_mongo_timeseries import query_indicators_for_unit
 from src.etl.load.load_predictions import persist_predictions
 from src.config.settings import Settings
 from src.database.connection import get_client


### PR DESCRIPTION
## 🔗 Related Issue

Closes #201 

---

## 📝 What was done?

Implemented actionable prediction pipeline API with two new endpoints:

1. **POST /predictions/generate** — Trigger background prediction generation
   - Accepts optional filters: `consumer_unit_set_id`, `indicator_types`, `year_start`, `year_end`
   - Returns immediately (HTTP 202) with `job_id` for tracking
   - Forecasts specific unit or all units in database (if not specified)
   - Executes in background via FastAPI `BackgroundTasks`
   - Calls `TimeSeriesForecastProcedures.forecast_for_unit()` for each consumer unit
   - Persists results via `persist_predictions()` with idempotent upsert

2. **GET /predictions/** — Query saved predictions with filtering & pagination
   - Optional filters: `consumer_unit_set_id`, `indicator` (DEC/FEC)
   - Pagination: `skip` and `limit` parameters
   - Sorted by `generated_on` descending (newest first)
   - Returns paginated list with total count
   - Response validated with Pydantic `Prediction` schema

3. **Helper Function** — `get_all_consumer_units()`
   - Queries distinct `consumer_unit_set_id` from `distribution_indices` collection
   - Used when `consumer_unit_set_id` not specified in POST request

4. **Integration** — Updated main.py to register predictions router

---

## 🧪 How to test locally

```bash
# 1. Start the environment (if not already running)
docker compose --profile full up

# 2. Wait for backend to be ready (~30 seconds)
sleep 30

# 3. Test POST /predictions/generate — forecast specific unit
curl -X POST "http://localhost:8000/predictions/generate?consumer_unit_set_id=16648&indicator_types=DEC&indicator_types=FEC&year_start=2015&year_end=2024"
# Expected: HTTP 202 with {status: "STARTED", job_id: "<uuid>", consumer_unit_set_id: "16648", ...}

# 4. Wait for background task to complete (monitor logs)
docker compose logs -f backend | grep "generate_predictions_task"
# Look for: "Completed. Total inserted: X, updated: Y, failed units: Z"

# 5. Query predictions via GET /predictions/
curl -X GET "http://localhost:8000/predictions/?consumer_unit_set_id=16648&indicator=DEC&skip=0&limit=50"
# Expected: HTTP 200 with {total: 24, skip: 0, limit: 50, predictions: [...]}

# 6. Verify predictions in MongoDB
docker exec -it mongo_db mongosh tecsys
# In mongosh shell:
db.predictions.countDocuments({consumer_unit_set_id: "16648"})
# Should return 24 (12 months × 2 indicators)

db.predictions.findOne({consumer_unit_set_id: "16648", indicator: "DEC"})
# Should show: consumer_unit_set_id, indicator, forecast_year, forecast_period, forecast_value, model, generated_on

# 7. Test filtering in GET endpoint
curl -X GET "http://localhost:8000/predictions/?indicator=FEC"
# Should return only FEC predictions

curl -X GET "http://localhost:8000/predictions/?consumer_unit_set_id=16648&indicator=DEC&limit=10"
# Should return paginated results (max 10 records)

# 8. Test bulk generation (all units) — optional
curl -X POST "http://localhost:8000/predictions/generate?year_start=2015&year_end=2024"
# Expected: HTTP 202 with consumer_unit_set_id: null (indicating all units)
# Check logs for progress on each unit

# 9. Verify idempotency (rerun forecast for same unit)
curl -X POST "http://localhost:8000/predictions/generate?consumer_unit_set_id=16648"
# Rerun GET to confirm predictions updated (not duplicated)
curl -X GET "http://localhost:8000/predictions/?consumer_unit_set_id=16648"
# Count should remain same; generated_on should be newer

# 10. Test error handling — invalid indicator
curl -X POST "http://localhost:8000/predictions/generate?consumer_unit_set_id=16648&indicator_types=INVALID"
# Expected: HTTP 400 with error message
```

---

## 📸 Evidence

<img width="1538" height="717" alt="image" src="https://github.com/user-attachments/assets/efa8d6d7-99a0-48e0-ba8b-734c302535b2" />

</br>

<img width="1614" height="976" alt="image" src="https://github.com/user-attachments/assets/bbaca143-6540-4698-9c55-c2cab35a596e" />


---

## ✅ Definition of Done

- [x] POST /predictions/generate endpoint triggers background forecasting
- [x] Returns HTTP 202 with job_id immediately (non-blocking)
- [x] Supports optional consumer_unit_set_id filter (forecasts all units if not specified)
- [x] Supports optional indicator_types filter (defaults to ["DEC", "FEC"])
- [x] Background task calls TimeSeriesForecastProcedures.forecast_for_unit()
- [x] Predictions persisted via persist_predictions() with idempotent upsert
- [x] GET /predictions/ endpoint queries saved predictions
- [x] GET supports filtering by consumer_unit_set_id and indicator
- [x] GET supports pagination (skip/limit)
- [x] GET sorted by generated_on descending (newest first)
- [x] Predictions validated with Pydantic Prediction schema
- [x] Helper function get_all_consumer_units() implemented
- [x] Router integrated in main.py

---

## ✅ Final Checklist

- [x] Code follows project style guide (consistent with upload.py, timeseries.py, decfec.py patterns)
- [x] Reviewed own code before submitting
- [x] Added docstrings for functions and endpoints (description, parameters, response format)
- [x] Error handling implemented (validation, logging, exception handlers)
- [x] No syntax errors (validated with Pylance)
- [x] All imports from existing modules (no new dependencies)
- [x] Follows existing POST + BackgroundTasks pattern (matching upload endpoint)
- [x] Follows existing GET + filtering pattern (matching decfec endpoint)
- [x] No breaking changes to existing endpoints
- [x] Background task logs progress and handles failures gracefully
- [x] Idempotency via MongoDB upsert (natural keys: consumer_unit_set_id, indicator, forecast_year, forecast_period)
