### PR TITLE
Feat/420 transparencia ao usuario

### DIFF
--- a/apps/backend/src/api/routes/users.py
+++ b/apps/backend/src/api/routes/users.py
@@ -1,13 +1,14 @@
 import structlog
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from typing import List
 from uuid import UUID
 
 from src.api.schemas.user_schemas import (
     ProfileResponse, UserCreateRequest, UserCreateResponse,
-    UserResult, UserUpdateRequest, UserSetActiveRequest,
+    UserMeResponse, UserMeUpdateRequest, UserResult, UserUpdateRequest, UserSetActiveRequest,
 )
+from src.api.dependencies.auth import AuthenticatedUser, get_current_user
 from src.config.log_events import (
     USER_CREATED, USER_UPDATED, USER_DEACTIVATED,
     USER_DELETED, USER_NOT_FOUND, USER_CONFLICT, USER_LISTED,
@@ -19,7 +20,8 @@ from src.repositories.user_repository import (
 from src.services.user_service import (
     create_user_service, list_profiles_service, get_user_by_id_service,
     list_users_service, update_user_service, set_user_active_service,
-    delete_user_service,
+    delete_user_service, get_current_user_profile_service,
+    update_current_user_profile_service,
 )
 
 router = APIRouter(prefix="/users", tags=["users"])
@@ -40,6 +42,36 @@ def get_profiles():
         return [ProfileResponse(profile_uuid=p.profile_uuid, profile_name=p.profile_name) for p in profiles]
     except ProfilePersistenceError as exc:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Falha ao listar perfis.") from exc
+
+
+@router.get("/me", response_model=UserMeResponse, status_code=status.HTTP_200_OK)
+def get_my_profile(current_user: AuthenticatedUser = Depends(get_current_user)):
+    try:
+        return get_current_user_profile_service(current_user.user_id)
+    except UserNotFoundError as exc:
+        log.warning(USER_NOT_FOUND, user_id=current_user.user_id)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.patch("/me", response_model=UserMeResponse, status_code=status.HTTP_200_OK)
+def update_my_profile(
+    payload: UserMeUpdateRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+):
+    try:
+        result = update_current_user_profile_service(
+            current_user.user_id,
+            username=payload.username,
+            email=str(payload.email),
+        )
+        log.info(USER_UPDATED, user_id=current_user.user_id, fields_changed=["username", "email"])
+        return result
+    except UserNotFoundError as exc:
+        log.warning(USER_NOT_FOUND, user_id=current_user.user_id)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except UserAlreadyExistsError as exc:
+        log.warning(USER_CONFLICT, user_id=current_user.user_id, reason=str(exc))
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
 
 @router.get("/{user_uuid}", response_model=UserResult, status_code=status.HTTP_200_OK)

--- a/apps/backend/src/api/schemas/user_schemas.py
+++ b/apps/backend/src/api/schemas/user_schemas.py
@@ -72,6 +72,26 @@ class UserUpdateRequest(BaseModel):
     profile_id: UUID
 
 
+class UserMeResponse(BaseModel):
+    user_uuid: UUID
+    username: str
+    email: EmailStr
+    profile_name: str
+    active: bool
+    first_access_completed: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class UserMeUpdateRequest(BaseModel):
+    username: str = Field(..., min_length=3, max_length=50)
+    email: EmailStr
+
+    @field_validator("email")
+    def normalize_email(cls, v: EmailStr) -> str:
+        return str(v).strip().lower()
+
+
 class UserSetActiveRequest(BaseModel):
     active: bool
 

--- a/apps/backend/src/repositories/user_repository.py
+++ b/apps/backend/src/repositories/user_repository.py
@@ -187,6 +187,91 @@ def exists_by_email_hash(conn: PgConnection, email_hash: str) -> bool:
         return cursor.fetchone() is not None
 
 
+def exists_by_email_hash_for_other_user(conn: PgConnection, email_hash: str, user_uuid: str) -> bool:
+    query = """
+        SELECT 1
+        FROM TB_USER
+        WHERE EMAIL_HASH = %s
+          AND USER_UUID <> %s
+        LIMIT 1
+    """
+
+    with conn.cursor() as cursor:
+        cursor.execute(query, (email_hash, str(user_uuid)))
+        return cursor.fetchone() is not None
+
+
+def get_current_user_profile(conn: PgConnection, user_uuid: str) -> dict | None:
+    query = """
+        SELECT
+            u.USER_UUID,
+            u.USERNAME,
+            u.EMAIL_ENC,
+            p.PROFILE_NAME,
+            u.ACTIVE,
+            u.FIRST_ACCESS_COMPLETED,
+            u.CREATED_AT,
+            u.UPDATED_AT
+        FROM TB_USER u
+        JOIN TB_PROFILE p
+          ON p.PROFILE_UUID = u.PROFILE_ID
+        WHERE u.USER_UUID = %s
+          AND u.DELETED_AT IS NULL
+        LIMIT 1
+    """
+
+    with conn.cursor() as cursor:
+        cursor.execute(query, (str(user_uuid),))
+        row = cursor.fetchone()
+
+    if row is None:
+        return None
+
+    return {
+        "user_uuid": row[0],
+        "username": row[1],
+        "email_enc": row[2],
+        "profile_name": row[3],
+        "active": row[4],
+        "first_access_completed": row[5],
+        "created_at": row[6],
+        "updated_at": row[7],
+    }
+
+
+def update_current_user_profile(conn: PgConnection, user_uuid: str, data: dict) -> dict | None:
+    query = """
+        UPDATE TB_USER
+        SET USERNAME = %s,
+            EMAIL_HASH = %s,
+            EMAIL_ENC = %s,
+            UPDATED_AT = NOW()
+        WHERE USER_UUID = %s
+          AND DELETED_AT IS NULL
+        RETURNING USER_UUID
+    """
+
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                query,
+                (
+                    data["username"],
+                    data["email_hash"],
+                    data["email_enc"],
+                    str(user_uuid),
+                ),
+            )
+            row = cursor.fetchone()
+    except UniqueViolation as exc:
+        raise UserAlreadyExistsError("Nome de usuÃ¡rio ou e-mail jÃ¡ cadastrado.") from exc
+
+    if row is None:
+        return None
+
+    return get_current_user_profile(conn, user_uuid)
+
+
 def update_user(conn: PgConnection, user_uuid: UUID, data: dict) -> Optional[UserResult]:
     query = """
         UPDATE TB_USER

--- a/apps/backend/src/services/user_service.py
+++ b/apps/backend/src/services/user_service.py
@@ -6,7 +6,7 @@ from typing import List
 from uuid import UUID
 
 import bcrypt
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 from fastapi import HTTPException
 from psycopg2 import IntegrityError, OperationalError
 
@@ -16,6 +16,7 @@ from src.config.email_hasher import EmailHasher
 from src.config.exception_handlers import handle_db_integrity_error, handle_db_operational_error
 from src.config.settings import Settings
 from src.database.postgres import get_pg_connection
+from src.database.postgres import set_current_user
 from src.repositories.user_repository import (
     ProfileResult,
     UserAlreadyExistsError,
@@ -27,12 +28,15 @@ from src.repositories.user_repository import (
     create_user,
     delete_user,
     exists_by_email_hash,
+    exists_by_email_hash_for_other_user,
     exists_by_profile_id,
     exists_by_username,
+    get_current_user_profile,
     get_user_by_id,
     list_profiles,
     list_users,
     set_user_active,
+    update_current_user_profile,
     update_user,
 )
 
@@ -190,6 +194,93 @@ def _encrypt_email(email: str, settings: Settings) -> str:
 
 def _hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def _decrypt_email(email_enc: str, settings: Settings) -> str:
+    key = _resolve_email_encryption_key(settings)
+    try:
+        return Fernet(key).decrypt(email_enc.encode("utf-8")).decode("utf-8")
+    except (InvalidToken, ValueError) as exc:
+        raise RuntimeError("Falha ao descriptografar o e-mail do usuario.") from exc
+
+
+def _format_current_user_profile(row: dict) -> dict:
+    settings = Settings()
+    return {
+        "user_uuid": row["user_uuid"],
+        "username": row["username"],
+        "email": _decrypt_email(row["email_enc"], settings),
+        "profile_name": row["profile_name"],
+        "active": row["active"],
+        "first_access_completed": row["first_access_completed"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def get_current_user_profile_service(user_id: str) -> dict:
+    try:
+        with get_pg_connection() as conn:
+            set_current_user(conn, user_id)
+            user = get_current_user_profile(conn, user_id)
+    except IntegrityError as exc:
+        handle_db_integrity_error(exc, context="get_current_user_profile_service")
+        raise HTTPException(status_code=409, detail="conflict")
+    except OperationalError as exc:
+        handle_db_operational_error(exc, context="get_current_user_profile_service")
+        raise HTTPException(status_code=503, detail="database_unavailable")
+
+    if user is None:
+        raise UserNotFoundError("Usuario nao encontrado.")
+
+    return _format_current_user_profile(user)
+
+
+def update_current_user_profile_service(user_id: str, username: str, email: str) -> dict:
+    settings = Settings()
+    normalized_username = username.strip().upper()
+    normalized_email = str(email).strip().lower()
+    email_hash = EmailHasher.hash(normalized_email)
+
+    try:
+        with get_pg_connection() as conn:
+            set_current_user(conn, user_id)
+            current_user = get_current_user_profile(conn, user_id)
+
+            if current_user is None:
+                raise UserNotFoundError("Usuario nao encontrado.")
+
+            if (
+                current_user["username"].upper() != normalized_username
+                and exists_by_username(conn, normalized_username)
+            ):
+                raise UserAlreadyExistsError("Nome de usuario ja cadastrado.")
+
+            if exists_by_email_hash_for_other_user(conn, email_hash, user_id):
+                raise UserAlreadyExistsError("E-mail ja cadastrado.")
+
+            result = update_current_user_profile(
+                conn,
+                user_id,
+                {
+                    "username": normalized_username,
+                    "email_hash": email_hash,
+                    "email_enc": _encrypt_email(normalized_email, settings),
+                },
+            )
+    except (UserNotFoundError, UserAlreadyExistsError):
+        raise
+    except IntegrityError as exc:
+        handle_db_integrity_error(exc, context="update_current_user_profile_service")
+        raise HTTPException(status_code=409, detail="conflict")
+    except OperationalError as exc:
+        handle_db_operational_error(exc, context="update_current_user_profile_service")
+        raise HTTPException(status_code=503, detail="database_unavailable")
+
+    if result is None:
+        raise UserNotFoundError("Usuario nao encontrado.")
+
+    return _format_current_user_profile(result)
 
 
 def list_profiles_service() -> List[ProfileResult]:

--- a/apps/frontend/src/api/consent.js
+++ b/apps/frontend/src/api/consent.js
@@ -22,7 +22,7 @@ export function getSessionToken() {
   return null;
 }
 
-function getAuthOptions() {
+export function getAuthOptions() {
   const token = getSessionToken();
 
   if (!token) {

--- a/apps/frontend/src/api/profile.js
+++ b/apps/frontend/src/api/profile.js
@@ -1,0 +1,10 @@
+import { apiClient } from "./client";
+import { getAuthOptions } from "./consent";
+
+export function getMyProfile() {
+  return apiClient.get("/users/me", getAuthOptions());
+}
+
+export function updateMyProfile(payload) {
+  return apiClient.patch("/users/me", payload, getAuthOptions());
+}

--- a/apps/frontend/src/pages/dashboard/profile/ProfilePage.jsx
+++ b/apps/frontend/src/pages/dashboard/profile/ProfilePage.jsx
@@ -1,0 +1,297 @@
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, CheckCircle2, Loader2, Mail, Save, Shield, Trash2, User } from "lucide-react";
+import { toast } from "sonner";
+
+import { getMyProfile, updateMyProfile } from "@/api/profile";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function getApiErrorMessage(error, fallbackMessage) {
+  const detail = error?.response?.data?.detail ?? error?.detail ?? error?.data?.detail;
+
+  if (typeof detail === "string" && detail.trim()) {
+    return detail;
+  }
+
+  if (Array.isArray(detail) && detail.length > 0) {
+    const firstDetail = detail[0];
+
+    if (typeof firstDetail === "string" && firstDetail.trim()) {
+      return firstDetail;
+    }
+
+    if (typeof firstDetail?.msg === "string" && firstDetail.msg.trim()) {
+      return firstDetail.msg;
+    }
+  }
+
+  return fallbackMessage;
+}
+
+function formatDateTime(value) {
+  if (!value) return "-";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState(null);
+  const [form, setForm] = useState({ username: "", email: "" });
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadProfile() {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const data = await getMyProfile();
+
+        if (!mounted) return;
+
+        setProfile(data);
+        setForm({
+          username: data.username || "",
+          email: data.email || "",
+        });
+      } catch (err) {
+        if (!mounted) return;
+        setError(getApiErrorMessage(err, "Nao foi possivel carregar seu perfil."));
+      } finally {
+        if (mounted) setIsLoading(false);
+      }
+    }
+
+    loadProfile();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const hasChanges = useMemo(() => {
+    if (!profile) return false;
+
+    return (
+      form.username.trim() !== profile.username ||
+      form.email.trim().toLowerCase() !== profile.email
+    );
+  }, [form.email, form.username, profile]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError("");
+
+    const username = form.username.trim();
+    const email = form.email.trim().toLowerCase();
+
+    if (username.length < 3) {
+      setError("Informe um nome com pelo menos 3 caracteres.");
+      return;
+    }
+
+    if (!emailPattern.test(email)) {
+      setError("Informe um email valido.");
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const updated = await updateMyProfile({ username, email });
+      setProfile(updated);
+      setForm({
+        username: updated.username || "",
+        email: updated.email || "",
+      });
+      toast.success("Perfil atualizado com sucesso.");
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Nao foi possivel atualizar seu perfil."));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[360px] items-center justify-center">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span className="text-sm">Carregando perfil...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground">Meu Perfil</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Consulte e atualize somente as informacoes vinculadas a sua propria conta.
+        </p>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
+        <Card className="rounded-lg">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <User className="h-4 w-4 text-primary" />
+              Dados cadastrais
+            </CardTitle>
+            <CardDescription>
+              Nome e email sao dados pessoais da sua conta e nao alteram seu cargo no sistema.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-foreground" htmlFor="profile-username">
+                  Nome
+                </label>
+                <div className="relative">
+                  <User className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="profile-username"
+                    name="username"
+                    value={form.username}
+                    onChange={handleChange}
+                    className="pl-9"
+                    autoComplete="name"
+                    disabled={isSaving}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-foreground" htmlFor="profile-email">
+                  Email
+                </label>
+                <div className="relative">
+                  <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="profile-email"
+                    name="email"
+                    type="email"
+                    value={form.email}
+                    onChange={handleChange}
+                    className="pl-9"
+                    autoComplete="email"
+                    disabled={isSaving}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-foreground" htmlFor="profile-role">
+                  Cargo
+                </label>
+                <div className="relative">
+                  <Shield className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="profile-role"
+                    value={profile?.profile_name || ""}
+                    className="pl-9"
+                    disabled
+                    readOnly
+                  />
+                </div>
+              </div>
+
+              <div className="flex justify-end">
+                <Button type="submit" disabled={isSaving || !hasChanges}>
+                  {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                  Salvar alteracoes
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <aside className="flex flex-col gap-4">
+          <Card className="rounded-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Shield className="h-4 w-4 text-primary" />
+                Acesso
+              </CardTitle>
+              <CardDescription>Estado atual da conta</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Status</span>
+                <span className="inline-flex items-center gap-1 rounded-full bg-chart-1/10 px-2 py-1 text-xs font-medium text-chart-1">
+                  <CheckCircle2 className="h-3 w-3" />
+                  {profile?.active ? "Ativo" : "Inativo"}
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Perfil</span>
+                <span className="rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                  {profile?.profile_name || "-"}
+                </span>
+              </div>
+              <div className="border-t border-border pt-3">
+                <p className="text-xs text-muted-foreground">Criado em</p>
+                <p className="mt-1 font-medium text-foreground">{formatDateTime(profile?.created_at)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Ultima atualizacao</p>
+                <p className="mt-1 font-medium text-foreground">{formatDateTime(profile?.updated_at)}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-lg border-destructive/30">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base text-destructive">
+                <Trash2 className="h-4 w-4" />
+                Exclusao da conta
+              </CardTitle>
+              <CardDescription>
+                Acao reservada para a proxima etapa do fluxo de LGPD.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                type="button"
+                variant="destructive"
+                className="w-full"
+                disabled
+                title="Funcionalidade ainda nao implementada"
+              >
+                <Trash2 className="h-4 w-4" />
+                Solicitar exclusao
+              </Button>
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/routes/index.jsx
+++ b/apps/frontend/src/routes/index.jsx
@@ -10,6 +10,7 @@ import IndicadoresPage from "../pages/dashboard/indicadores-page/IndicadoresPage
 import EstruturaRedesPage from "../pages/dashboard/estrutura-redes-page/EstruturaRedesPage";
 import UsuariosPage from "../pages/dashboard/user-management/UsuariosPage";
 import TermsPage from "../pages/dashboard/terms-management/TermsPage";
+import ProfilePage from "../pages/dashboard/profile/ProfilePage";
 
 function NotFoundPage() {
   return (
@@ -33,6 +34,7 @@ export function AppRoutes() {
             <Route index element={<Navigate to="indicadores" replace />} />
             <Route path="indicadores" element={<IndicadoresPage />} />
             <Route path="estrutura-redes" element={<EstruturaRedesPage />} />
+            <Route path="perfil" element={<ProfilePage />} />
             <Route path="usuarios" element={<RoleRequiredRoute allowedProfiles={["ADMIN","MANAGER"]}><UsuariosPage /></RoleRequiredRoute>} />
             <Route path="termos" element={<RoleRequiredRoute allowedProfiles={["ADMIN"]}><TermsPage /></RoleRequiredRoute>} />
             <Route path="*" element={<NotFoundPage />} />


### PR DESCRIPTION
## 🔗 Related Issue

> Auto-detected from branch. Confirm or edit if needed.
> Branch: `feature/420-meu-perfil` → Issue: #420

Closes #420

---

## 📝 What was done?

> Explain what was implemented and why. Be specific about the approach taken.

- Implemented the **Meu Perfil** screen at `/dashboard/perfil`.
- Added backend endpoints for authenticated users:
  - `GET /users/me` to return only the logged-in user's own profile data.
  - `PATCH /users/me` to update only the logged-in user's editable personal data.
- Allowed users to edit their own `username` and `email`.
- Kept profile/cargo as read-only, so users cannot change their own role.
- Updated email persistence by recalculating `EMAIL_HASH` and `EMAIL_ENC`.
- Added frontend API helpers in `apps/frontend/src/api/profile.js`.
- Added a disabled **Solicitar exclusão** button as a visual placeholder for the future LGPD account deletion flow.

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

```bash
# 1. Start the environment
docker compose up

# 2. Install frontend dependencies if needed
corepack pnpm install

# 3. Start the frontend
corepack pnpm --dir apps/frontend dev

# 4. Open the app
# http://localhost:5173/dashboard/perfil
```

Reviewer validation:
- Log in with a valid user.
- Open `/dashboard/perfil`.
- Confirm that only the logged-in user's data is shown.
- Edit name and email, then save.
- Confirm that cargo/perfil is visible but cannot be edited.
- Confirm that the account deletion button is visible but disabled.
- Confirm that another user's data is not shown or editable.

---

## ⚠️ Risks and Potential Impact

> Describe possible side effects or risks of this change.

- User email updates now modify both `EMAIL_HASH` and `EMAIL_ENC`; login must use the new email after update.
- The profile update endpoint depends on the authenticated session token, so expired or invalid sessions will block access.
- Account deletion is only a disabled frontend placeholder; no deletion/anonymization behavior was implemented yet.

---

## 📸 Evidence

> Add screenshots, logs or relevant outputs.

- Build validation:

```bash
corepack pnpm --dir apps/frontend build
# ✓ built successfully
```

- Backend syntax validation:

```bash
python -m py_compile apps/backend/src/api/routes/users.py apps/backend/src/api/schemas/user_schemas.py apps/backend/src/repositories/user_repository.py apps/backend/src/services/user_service.py
# passed
```

---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] New and existing tests pass with my changes