### PR TITLE
Feature/421 politica de privacidade

### DIFF
--- a/apps/backend/src/api/routes/consent.py
+++ b/apps/backend/src/api/routes/consent.py
@@ -40,7 +40,16 @@ def get_pending_consent_route(
     return {"pending_clauses": pending_clauses}
 
 
-@router.get("/history/{user_id}", response_model=ConsentHistoryResponse)
+@router.get(
+    "/history/{user_id}",
+    response_model=ConsentHistoryResponse,
+    summary="Consultar historico de consentimento de um usuario",
+    description=(
+        "Endpoint administrativo para auditoria LGPD. "
+        "Retorna os eventos imutaveis de aceite e revogacao de termos "
+        "registrados para o usuario informado. Requer perfil ADMIN."
+    ),
+)
 def get_user_consent_history_for_audit(
     user_id: UUID,
     admin: AuthenticatedUser = Depends(require_admin),

--- a/apps/backend/src/api/routes/consent.py
+++ b/apps/backend/src/api/routes/consent.py
@@ -1,12 +1,18 @@
 from fastapi import APIRouter, Depends, Request
+from uuid import UUID
 
 from src.api.dependencies.auth import (
     AuthenticatedUser,
     get_current_user_no_consent_check,
+    require_admin,
 )
-from src.api.schemas.consent import ConsentRequest
+from src.api.schemas.consent import ConsentHistoryResponse, ConsentRequest
 from src.database.postgres import get_pg_connection, set_current_user
-from src.services.consent_service import get_pending_consent, submit_consent_batch
+from src.services.consent_service import (
+    get_pending_consent,
+    get_user_consent_history,
+    submit_consent_batch,
+)
 
 
 router = APIRouter(prefix="/consent", tags=["consent"])
@@ -32,6 +38,21 @@ def get_pending_consent_route(
         pending_clauses = get_pending_consent(conn, current_user.user_id)
 
     return {"pending_clauses": pending_clauses}
+
+
+@router.get("/history/{user_id}", response_model=ConsentHistoryResponse)
+def get_user_consent_history_for_audit(
+    user_id: UUID,
+    admin: AuthenticatedUser = Depends(require_admin),
+):
+    with get_pg_connection() as conn:
+        set_current_user(conn, admin.user_id)
+        history = get_user_consent_history(conn, str(user_id))
+
+    return {
+        "user_id": user_id,
+        "history": history,
+    }
 
 
 @router.post("")

--- a/apps/backend/src/api/schemas/consent.py
+++ b/apps/backend/src/api/schemas/consent.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
@@ -43,3 +44,22 @@ class ConsentActionIn(BaseModel):
 
 class ConsentRequest(BaseModel):
     actions: list[ConsentActionIn] = Field(default_factory=list)
+
+
+class ConsentHistoryItem(BaseModel):
+    log_uuid: UUID
+    action: str
+    registered_at: datetime
+    channel: str
+    policy_version_id: UUID
+    policy_type: str
+    policy_version: str
+    clause_uuid: UUID
+    clause_code: str
+    clause_title: str
+    mandatory: bool
+
+
+class ConsentHistoryResponse(BaseModel):
+    user_id: UUID
+    history: list[ConsentHistoryItem]

--- a/apps/backend/src/repositories/consent_repository.py
+++ b/apps/backend/src/repositories/consent_repository.py
@@ -63,6 +63,39 @@ def list_pending_clauses(conn, user_id: str) -> list[dict]:
         return cur.fetchall()
 
 
+def list_user_consent_history(conn, user_id: str) -> list[dict]:
+    """
+    Lists immutable consent events for one authenticated user.
+    """
+    with dict_cursor(conn) as cur:
+        cur.execute(
+            """
+            SELECT
+                cl.LOG_UUID,
+                cl.ACTION,
+                cl.CREATED_AT AS REGISTERED_AT,
+                cl.CHANNEL,
+                pv.VERSION_UUID AS POLICY_VERSION_ID,
+                pv.POLICY_TYPE,
+                pv.VERSION AS POLICY_VERSION,
+                pc.CLAUSE_UUID,
+                pc.CODE AS CLAUSE_CODE,
+                pc.TITLE AS CLAUSE_TITLE,
+                pc.MANDATORY
+            FROM TB_CONSENT_LOG cl
+            JOIN TB_POLICY_CLAUSE pc
+              ON pc.CLAUSE_UUID = cl.CLAUSE_ID
+            JOIN TB_POLICY_VERSION pv
+              ON pv.VERSION_UUID = COALESCE(cl.POLICY_VERSION_ID, pc.POLICY_VERSION_ID)
+            WHERE cl.USER_ID = %s
+            ORDER BY cl.CREATED_AT DESC, cl.LOG_UUID DESC
+            """,
+            (user_id,),
+        )
+
+        return cur.fetchall()
+
+
 def list_current_mandatory_clauses(conn) -> list[dict]:
     """
     Lists all mandatory clauses from currently effective policy versions.

--- a/apps/backend/src/services/consent_service.py
+++ b/apps/backend/src/services/consent_service.py
@@ -85,6 +85,41 @@ def get_pending_consent(conn, user_id: str) -> list[dict]:
     return format_pending_clauses(rows)
 
 
+def format_consent_history(rows: list[dict]) -> list[dict]:
+    return [
+        {
+            "log_uuid": row["log_uuid"],
+            "action": row["action"],
+            "registered_at": row["registered_at"],
+            "channel": row["channel"],
+            "policy_version_id": row["policy_version_id"],
+            "policy_type": row["policy_type"],
+            "policy_version": row["policy_version"],
+            "clause_uuid": row["clause_uuid"],
+            "clause_code": row["clause_code"],
+            "clause_title": row["clause_title"],
+            "mandatory": row["mandatory"],
+        }
+        for row in rows
+    ]
+
+
+def get_user_consent_history(conn, user_id: str) -> list[dict]:
+    """
+    Returns immutable consent history for the authenticated user.
+    """
+    try:
+        rows = consent_repository.list_user_consent_history(conn, user_id)
+    except IntegrityError as exc:
+        handle_db_integrity_error(exc, context="get_user_consent_history")
+        raise HTTPException(status_code=409, detail="conflict")
+    except OperationalError as exc:
+        handle_db_operational_error(exc, context="get_user_consent_history")
+        raise HTTPException(status_code=503, detail="database_unavailable")
+
+    return format_consent_history(rows)
+
+
 def _get_action_value(action_item) -> str:
     action = getattr(action_item, "action", None)
 


### PR DESCRIPTION
## 🔗 Related Issue

> Auto-detected from branch. Confirm or edit if needed.
> Branch: `feature/421-consent-history-audit` → Issue: #421

Closes #421

---

## 📝 What was done?

> Explain what was implemented and why. Be specific about the approach taken.

- Added a backend-only audit endpoint to retrieve a user's consent history.
- Implemented `GET /consent/history/{user_id}` for ADMIN users.
- The endpoint returns immutable consent events from `TB_CONSENT_LOG`, joined with `TB_POLICY_CLAUSE` and `TB_POLICY_VERSION`.
- The response includes accepted/revoked action, timestamp, channel, policy type, policy version, clause code/title, and mandatory flag.
- Added response schemas for Swagger/OpenAPI documentation.
- Added Swagger summary and description clarifying that the endpoint is for LGPD audit and requires ADMIN access.
- No frontend screen was implemented because this flow is intended for Postman/audit usage.

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

```bash
# 1. Start the environment
docker compose up

# 2. Authenticate as an ADMIN user and copy the access token

# 3. Call the audit endpoint with a target user UUID
curl -H "Authorization: Bearer <token_admin>" \
  http://localhost:8000/consent/history/<user_uuid>

# 4. Open Swagger and confirm the endpoint is documented
# http://localhost:8000/docs
```

Expected result:
- ADMIN receives `200 OK` with the user's consent history.
- Non-admin users receive `403 admin_required`.
- Invalid or missing token receives authentication error.

---

## ⚠️ Risks and Potential Impact

> Describe possible side effects or risks of this change.

- This endpoint exposes consent audit history, so it is restricted to ADMIN users only.
- It is backend-only; no frontend flow was added.
- If a user has no consent records, the endpoint returns an empty `history` array.
- The endpoint depends on existing consent records in `TB_CONSENT_LOG`.

---

## 📸 Evidence

> Add screenshots, logs or relevant outputs.

- Backend syntax validation:

```bash
python -m py_compile apps/backend/src/api/routes/consent.py apps/backend/src/api/schemas/consent.py apps/backend/src/repositories/consent_repository.py apps/backend/src/services/consent_service.py
# passed
```

- Swagger path available:

```http
GET /consent/history/{user_id}
```

---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] New and existing tests pass with my changes

<details>
<summary>✨ Traceability</summary>

**Issue:** #421
**Type:** `feature`
**Branch:** `feature/421-politica-de-privacidade`

</details>