### PR TITLE
Feature/444 add geo endpoint for retrieving CONJ documents as GeoJSON

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -14,6 +14,7 @@ from src.api.routes import tam_sam
 from src.api.routes import timeseries
 from src.api.routes import upload
 from src.api.routes import gdb
+from src.api.routes import geo
 from src.api.routes import users
 from src.api.routes import auth
 from src.api.routes import consent
@@ -32,6 +33,7 @@ app.include_router(energy_losses.router)
 app.include_router(network_structure.router)
 app.include_router(upload.router)
 app.include_router(gdb.router)
+app.include_router(geo.router, prefix="/geo")
 app.include_router(tam_sam.router)
 app.include_router(timeseries.router)
 app.include_router(predictions.router)

--- a/apps/backend/src/api/routes/geo.py
+++ b/apps/backend/src/api/routes/geo.py
@@ -1,0 +1,78 @@
+from typing import List, Dict, Any, Optional, Literal
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pymongo.database import Database
+
+from src.database.connection import get_db
+
+router = APIRouter()
+
+
+@router.get("/conj")
+def get_conj(
+    year: Optional[int] = Query(default=None, ge=1900, le=2100),
+    indicator_type_code: Optional[Literal["DEC", "FEC"]] = Query(default=None),
+    db: Database = Depends(get_db),
+):
+    """Return CONJ documents as a GeoJSON FeatureCollection.
+
+    Projects only `code`, `name` and `geometry`. Filters out documents
+    without a filled `geometry` field and skips invalid geometries.
+    """
+    try:
+        filters: Dict[str, Any] = {"geometry": {"$exists": True, "$ne": None}}
+        elem_match: Dict[str, Any] = {}
+        if year is not None:
+            elem_match["year"] = year
+        if indicator_type_code is not None:
+            elem_match["indicator_type_code"] = indicator_type_code
+        if elem_match:
+            filters["annual_summaries"] = {"$elemMatch": elem_match}
+
+        cursor = db["conj"].find(
+            filters,
+            {"code": 1, "name": 1, "geometry": 1, "annual_summaries": 1, "_id": 0},
+        )
+
+        features: List[Dict[str, Any]] = []
+        for doc in cursor:
+            geometry = doc.get("geometry")
+            # Basic validation: must be a dict with type and coordinates
+            if not isinstance(geometry, dict) or "type" not in geometry or "coordinates" not in geometry:
+                continue
+
+            annual_summaries = doc.get("annual_summaries") or []
+            valid_summaries = [s for s in annual_summaries if isinstance(s, dict)]
+
+            if year is not None or indicator_type_code is not None:
+                summary = next(
+                    (
+                        s
+                        for s in valid_summaries
+                        if (year is None or s.get("year") == year)
+                        and (
+                            indicator_type_code is None
+                            or s.get("indicator_type_code") == indicator_type_code
+                        )
+                    ),
+                    None,
+                )
+                if summary is None:
+                    continue
+            else:
+                summary = valid_summaries[0] if valid_summaries else {}
+
+            properties = {
+                "code": doc.get("code"),
+                "name": doc.get("name"),
+                "indicator_type_code": summary.get("indicator_type_code") if summary else None,
+                "year": summary.get("year") if summary else None,
+                "limit": summary.get("limit") if summary else None,
+                "accumulated_value": summary.get("accumulated_value") if summary else None,
+                "periods_count": summary.get("periods_count") if summary else None,
+            }
+            features.append({"type": "Feature", "properties": properties, "geometry": geometry})
+
+        return {"type": "FeatureCollection", "features": features}
+
+    except Exception:
+        raise HTTPException(status_code=500, detail="Error reading CONJ collection")


### PR DESCRIPTION
## 🔗 Related Issue

Closes #444

---

## 📝 What was done?

- Created `src/api/routes/geo.py` with public `GET /geo/conj` endpoint
- Implemented GeoJSON FeatureCollection response format
- Added optional query filters for `year` (int) and `indicator_type_code` (DEC/FEC)
- Returns only CONJ documents with valid geometry
- Projects `code`, `name`, `indicator_type_code`, `year`, `limit`, `accumulated_value`, `periods_count` in GeoJSON properties
- Registered router in main.py with `/geo` prefix
- Endpoint accessible without JWT authentication

---

## 🧪 How to test locally

```bash
# 1. Start the environment
docker compose --profile backend up -d

# 2. Test endpoint without filters (returns all CONJ with geometry)
curl http://localhost:8000/geo/conj | jq '.type, .features | length'

# 3. Test with year filter
curl "http://localhost:8000/geo/conj?year=2012" | jq '.features | length'

# 4. Test with indicator filter
curl "http://localhost:8000/geo/conj?indicator_type_code=FEC" | jq '.features | length'

# 5. Test with combined filters
curl "http://localhost:8000/geo/conj?year=2012&indicator_type_code=FEC" | jq '.features[0].properties'

# 6. Verify Swagger documentation
# Open http://localhost:8000/docs and search for /geo/conj endpoint
```

---

## ⚠️ Risks and Potential Impact

- Large FeatureCollections with many CONJs may impact frontend rendering performance (consider pagination in future iterations)
- No request rate limiting implemented (may need to add if public API)
- Database query without pagination could timeout with very large datasets

---

## 📸 Evidence

**Endpoint Response Example (filtered):**
```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "code": "15555",
        "name": "ARARETAMA",
        "indicator_type_code": "FEC",
        "year": 2012,
        "limit": 7.0,
        "accumulated_value": null,
        "periods_count": 1
      },
      "geometry": {
        "type": "MultiPolygon",
        "coordinates": [[[ -45.513, -22.943, ...etc... ]]]
      }
    }
  ]
}
```

**Test Results:**
- ✅ Swagger documentation: `/geo/conj` appears in OpenAPI spec
- ✅ No filters: 52 features returned
- ✅ With `year=2012&indicator_type_code=FEC`: 35 features returned
- ✅ HTTP 200 status code
- ✅ Valid GeoJSON FeatureCollection format

---

## ✅ Definition of Done

- [x] Create src/api/routes/geo.py with APIRouter
- [x] Implement GET /conj using Depends(get_db) to access MongoDB
- [x] Filter only CONJs with a filled geometry
- [x] Return GeoJSON FeatureCollection with code, name, and geometry per Feature
- [x] Include indicator_type_code, year, limit, accumulated_value, periods_count in properties
- [x] Add optional year and indicator_type_code query filters
- [x] Endpoint accessible without JWT token
- [x] Register the router in main.py with prefix /geo
- [x] Confirm the endpoint appears in Swagger at http://localhost:8000/docs

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] Endpoint tested with curl and verified in Swagger docs
- [x] No sensitive data exposed in response (excluded `_id`, `arat_id`, `geodatabase_id`)

<details>
<summary>✨ Traceability</summary>

**Issue:** #444
**Type:** `feature`
**Branch:** `feature/444-get-geo-conj-endpoint-basic-geojson`

</details>