### PR TITLE
fix(users): set user active status to false on logical deletion

### DIFF
--- a/apps/backend/src/repositories/user_repository.py
+++ b/apps/backend/src/repositories/user_repository.py
@@ -260,6 +260,7 @@ def delete_user(conn: PgConnection, user_uuid: UUID) -> bool:
     query = """
         UPDATE TB_USER
         SET DELETED_AT = NOW(),
+            ACTIVE = FALSE,
             UPDATED_AT = NOW()
         WHERE USER_UUID = %s
           AND DELETED_AT IS NULL


### PR DESCRIPTION
## 🔗 Related Issue

Closes #460

---

## 📝 What was done?

- Fixed the delete_user() method in apps/backend/src/repositories/user_repository.py so that logical deletion now atomically updates DELETED_AT, ACTIVE, and UPDATED_AT fields, ensuring consistency with the business rules defined in the related user stories.

---

## 🧪 How to test locally

```bash
# 1. Build and start the environment
docker compose --profile full up --build

# 2. Create a user via POST /users and save the returned user_uuid

# 3 Delete the user via DELETE /users/{user_uuid}

# 4. Enter the postgres container
docker compose exec postgres bash

# 5. Enter psql
psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"

# 6. Inspect the deleted user's record
SELECT
    user_uuid,
    username,
    active,
    created_at,
    updated_at,
    deleted_at
FROM tb_user
WHERE user_uuid = 'PASTE_THE_UUID_HERE';

# 7. Validate the result
- active  → false
- deleted_at  → populated with the date and time of deletion
- updated_at  → updated atomically alongside deleted_at

```
---

## ⚠️ Risks and Potential Impact

- Queries filtering solely by ACTIVE will now correctly reflect logically deleted users; any behavior that relied on the previous inconsistent state may be affected.

---

## 📸 Evidence

### Activate False
<img width="1420" height="117" alt="image" src="https://github.com/user-attachments/assets/97a765b6-8c20-4543-b1bb-b6a43035250b" />

---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [ ] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] New and existing tests pass with my changes

<details>
<summary>🐛 Traceability</summary>

**Issue:** #460
**Type:** `bugfix`
**Branch:** `bugfix/460-logical-deletion-does-not-set-active-false`

</details>