### PR TITLE
Feature/466 data breach notification panel

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -21,6 +21,7 @@ from src.api.routes import consent
 from src.api.routes import terms
 from src.api.routes import admin_terms
 from src.api.routes import predictions
+from src.api.routes import incident_notification
 
 from src.config.lifespan import lifespan
 
@@ -42,6 +43,7 @@ app.include_router(auth.router)
 app.include_router(consent.router)
 app.include_router(terms.router)
 app.include_router(admin_terms.router)
+app.include_router(incident_notification.router)
 
 app.add_exception_handler(Exception, unhandled_exception_handler)
 app.add_exception_handler(HTTPException, http_exception_handler)

--- a/apps/backend/src/api/routes/incident_notification.py
+++ b/apps/backend/src/api/routes/incident_notification.py
@@ -1,0 +1,66 @@
+import structlog
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from typing import List
+
+from src.api.dependencies.auth import AuthenticatedUser, require_admin
+from src.api.schemas.incident_notification_schemas import (
+    SendNotificationRequest,
+    SendNotificationResponse,
+    TemplateResponse,
+)
+from src.config.log_events import INCIDENT_NOTIFICATION_SENT
+from src.services.incident_notification_service import (
+    dispatch_emails_task,
+    get_templates_service,
+    prepare_notification_service,
+)
+
+
+router = APIRouter(
+    prefix="/admin/incident-notification",
+    tags=["incident-notification"],
+    dependencies=[Depends(require_admin)],
+)
+log = structlog.get_logger()
+
+
+@router.get("/templates", response_model=List[TemplateResponse], status_code=status.HTTP_200_OK)
+def list_templates():
+    return get_templates_service()
+
+
+@router.post("/send", response_model=SendNotificationResponse, status_code=status.HTTP_202_ACCEPTED)
+def send_notification(
+    payload: SendNotificationRequest,
+    background_tasks: BackgroundTasks,
+    admin: AuthenticatedUser = Depends(require_admin),
+):
+    try:
+        emails, subject, body_html, body_text, recipient_count = prepare_notification_service(
+            admin_id=admin.user_id,
+            template_id=payload.template_id,
+            custom_subject=payload.custom_subject,
+            custom_body=payload.custom_body,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Falha ao preparar o envio da notificação.",
+        ) from exc
+
+    background_tasks.add_task(dispatch_emails_task, emails, subject, body_html, body_text)
+
+    log.info(
+        INCIDENT_NOTIFICATION_SENT,
+        admin_id=admin.user_id,
+        template_id=payload.template_id,
+        recipient_count=recipient_count,
+    )
+
+    return SendNotificationResponse(
+        recipient_count=recipient_count,
+        message="Notificação agendada para envio.",
+    )

--- a/apps/backend/src/api/schemas/incident_notification_schemas.py
+++ b/apps/backend/src/api/schemas/incident_notification_schemas.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+
+class SendNotificationRequest(BaseModel):
+    template_id: str
+    custom_subject: Optional[str] = None
+    custom_body: Optional[str] = None
+
+    @field_validator("custom_subject")
+    @classmethod
+    def subject_not_blank(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            raise ValueError("custom_subject não pode ser uma string vazia.")
+        return v
+
+    @field_validator("custom_body")
+    @classmethod
+    def body_not_blank(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            raise ValueError("custom_body não pode ser uma string vazia.")
+        return v
+
+
+class SendNotificationResponse(BaseModel):
+    recipient_count: int
+    message: str
+
+
+class TemplateResponse(BaseModel):
+    template_id: str
+    name: str
+    subject: str
+    body: str

--- a/apps/backend/src/config/log_events.py
+++ b/apps/backend/src/config/log_events.py
@@ -14,3 +14,6 @@ POLICY_CLAUSE_CREATED = "policy.clause.created"
 # Consent events
 CONSENT_REGISTERED = "consent.registered"
 CONSENT_REVOKED = "consent.revoked"
+
+# Incident notification events
+INCIDENT_NOTIFICATION_SENT = "incident.notification.sent"

--- a/apps/backend/src/repositories/incident_notification_repository.py
+++ b/apps/backend/src/repositories/incident_notification_repository.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from psycopg2.extensions import connection as PgConnection
+
+
+def list_active_user_email_enc(conn: PgConnection) -> List[str]:
+    """Returns EMAIL_ENC of active users who completed first access."""
+    query = """
+        SELECT EMAIL_ENC
+        FROM TB_USER
+        WHERE ACTIVE = TRUE
+          AND DELETED_AT IS NULL
+          AND FIRST_ACCESS_COMPLETED = TRUE
+    """
+    with conn.cursor() as cursor:
+        cursor.execute(query)
+        rows = cursor.fetchall()
+    return [row[0] for row in rows]

--- a/apps/backend/src/services/email_service.py
+++ b/apps/backend/src/services/email_service.py
@@ -103,3 +103,56 @@ Se você não solicitou este acesso, ignore este email.
     except Exception as e:
         logger.error(f"Failed to send first-access email: {e}")
         raise
+
+
+def send_bulk_incident_notification(
+    to_addresses: list,
+    subject: str,
+    body_html: str,
+    body_text: str,
+) -> dict:
+    """
+    Send a notification email to all addresses in the list.
+    Returns a dict with 'sent' and 'failed' counts.
+    Failures per recipient are logged but do not abort the batch.
+    """
+    settings = Settings()
+
+    if not settings.smtp_host or not settings.smtp_user or not settings.smtp_password or not settings.smtp_from:
+        logger.warning("SMTP settings not configured. Skipping bulk incident notification.")
+        return {"sent": 0, "failed": len(to_addresses)}
+
+    sent = 0
+    failed = 0
+
+    try:
+        with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=30) as server:
+            server.starttls()
+            server.login(settings.smtp_user, settings.smtp_password)
+
+            for address in to_addresses:
+                try:
+                    msg = MIMEMultipart("alternative")
+                    msg["Subject"] = subject
+                    msg["From"] = settings.smtp_from
+                    msg["To"] = address
+                    msg.attach(MIMEText(body_text, "plain"))
+                    msg.attach(MIMEText(body_html, "html"))
+                    server.send_message(msg)
+                    sent += 1
+                except Exception as exc:
+                    logger.error(f"Failed to send incident notification to {address}: {exc}")
+                    failed += 1
+
+    except smtplib.SMTPAuthenticationError as exc:
+        logger.error(f"SMTP authentication failed for bulk send: {exc}")
+        return {"sent": 0, "failed": len(to_addresses)}
+    except smtplib.SMTPException as exc:
+        logger.error(f"SMTP error in bulk send: {exc}")
+        return {"sent": sent, "failed": failed + (len(to_addresses) - sent - failed)}
+    except Exception as exc:
+        logger.error(f"Unexpected error in bulk send: {exc}")
+        return {"sent": sent, "failed": failed + (len(to_addresses) - sent - failed)}
+
+    logger.info(f"Bulk incident notification complete. sent={sent}, failed={failed}")
+    return {"sent": sent, "failed": failed}

--- a/apps/backend/src/services/incident_notification_service.py
+++ b/apps/backend/src/services/incident_notification_service.py
@@ -1,0 +1,176 @@
+"""Service for LGPD Art. 48 incident notification dispatch."""
+
+import logging
+from typing import List
+
+from psycopg2 import IntegrityError, OperationalError
+
+from src.config.exception_handlers import handle_db_integrity_error, handle_db_operational_error
+from src.config.settings import Settings
+from src.database.postgres import get_pg_connection
+from src.repositories.incident_notification_repository import list_active_user_email_enc
+from src.services.email_service import send_bulk_incident_notification
+from src.services.user_service import _decrypt_email
+
+
+logger = logging.getLogger(__name__)
+
+TEMPLATES = [
+    {
+        "template_id": "cyberattack_data_breach",
+        "name": "Ataque Cibernético / Violação de Dados",
+        "subject": "Notificação de Incidente de Segurança – Violação de Dados",
+        "body": (
+            "Prezado(a) usuário(a),\n\n"
+            "Informamos que nossa plataforma sofreu um incidente de segurança envolvendo "
+            "acesso não autorizado a dados pessoais. Identificamos a ocorrência e "
+            "imediatamente adotamos medidas de contenção.\n\n"
+            "Dados potencialmente afetados: nome, endereço de e-mail e informações de conta.\n\n"
+            "Medidas adotadas:\n"
+            "- Isolamento dos sistemas afetados\n"
+            "- Alteração de credenciais de acesso\n"
+            "- Notificação à Autoridade Nacional de Proteção de Dados (ANPD), "
+            "conforme Art. 48 da LGPD\n\n"
+            "Recomendamos que você altere sua senha imediatamente e permaneça atento "
+            "a comunicações suspeitas.\n\n"
+            "Você tem o direito de solicitar informações sobre o tratamento de seus dados, "
+            "nos termos dos artigos 17 a 22 da Lei nº 13.709/2018 (LGPD). "
+            "Para exercer seus direitos ou obter mais informações, entre em contato conosco.\n\n"
+            "Atenciosamente,\nEquipe Zeus"
+        ),
+    },
+    {
+        "template_id": "infrastructure_failure",
+        "name": "Falha de Infraestrutura / Perda de Dados",
+        "subject": "Comunicado de Incidente – Falha de Infraestrutura",
+        "body": (
+            "Prezado(a) usuário(a),\n\n"
+            "Comunicamos a ocorrência de uma falha de infraestrutura em nossos sistemas "
+            "que pode ter resultado em perda parcial ou total de dados associados à sua conta.\n\n"
+            "Medidas adotadas:\n"
+            "- Recuperação dos sistemas a partir de backups disponíveis\n"
+            "- Auditoria completa da integridade dos dados\n"
+            "- Notificação à Autoridade Nacional de Proteção de Dados (ANPD), "
+            "conforme Art. 48 da LGPD\n\n"
+            "Caso identifique inconsistências nos seus dados, entre em contato imediatamente "
+            "com nossa equipe de suporte.\n\n"
+            "Você tem o direito de solicitar informações sobre o tratamento de seus dados, "
+            "nos termos dos artigos 17 a 22 da Lei nº 13.709/2018 (LGPD).\n\n"
+            "Atenciosamente,\nEquipe Zeus"
+        ),
+    },
+    {
+        "template_id": "accidental_exposure",
+        "name": "Exposição Acidental de Dados",
+        "subject": "Notificação de Incidente de Privacidade – Exposição Acidental de Dados",
+        "body": (
+            "Prezado(a) usuário(a),\n\n"
+            "Informamos que, em virtude de uma falha de configuração identificada em nossos "
+            "sistemas, dados pessoais de usuários da plataforma foram expostos de forma "
+            "não intencional a terceiros não autorizados.\n\n"
+            "Medidas adotadas:\n"
+            "- Correção imediata da configuração inadequada\n"
+            "- Auditoria dos acessos realizados durante o período de exposição\n"
+            "- Notificação à Autoridade Nacional de Proteção de Dados (ANPD), "
+            "conforme Art. 48 da LGPD\n\n"
+            "Pedimos desculpas pelo ocorrido e reforçamos o nosso compromisso com a "
+            "proteção dos seus dados pessoais.\n\n"
+            "Você tem o direito de solicitar informações sobre o tratamento de seus dados, "
+            "nos termos dos artigos 17 a 22 da Lei nº 13.709/2018 (LGPD). "
+            "Para exercer seus direitos, entre em contato conosco.\n\n"
+            "Atenciosamente,\nEquipe Zeus"
+        ),
+    },
+]
+
+_TEMPLATES_BY_ID = {t["template_id"]: t for t in TEMPLATES}
+
+
+def get_templates_service() -> List[dict]:
+    return [
+        {
+            "template_id": t["template_id"],
+            "name": t["name"],
+            "subject": t["subject"],
+            "body": t["body"],
+        }
+        for t in TEMPLATES
+    ]
+
+
+def prepare_notification_service(
+    admin_id: str,
+    template_id: str,
+    custom_subject: str | None,
+    custom_body: str | None,
+) -> tuple:
+    """
+    Resolves the template and decrypts recipient emails.
+    Returns (emails, subject, body_html, body_text, recipient_count).
+    """
+    template = _TEMPLATES_BY_ID.get(template_id)
+    if template is None:
+        raise ValueError(f"Template '{template_id}' não encontrado.")
+
+    subject = custom_subject.strip() if custom_subject else template["subject"]
+    body_text = custom_body.strip() if custom_body else template["body"]
+    body_html = _body_to_html(subject, body_text)
+
+    try:
+        with get_pg_connection() as conn:
+            enc_emails = list_active_user_email_enc(conn)
+    except IntegrityError as exc:
+        handle_db_integrity_error(exc, context="prepare_notification_service")
+        raise
+    except OperationalError as exc:
+        handle_db_operational_error(exc, context="prepare_notification_service")
+        raise
+
+    settings = Settings()
+    emails: List[str] = []
+    for enc in enc_emails:
+        try:
+            emails.append(_decrypt_email(enc, settings))
+        except Exception:
+            logger.warning("Could not decrypt an email address; skipping.")
+
+    return emails, subject, body_html, body_text, len(emails)
+
+
+def dispatch_emails_task(emails: List[str], subject: str, body_html: str, body_text: str) -> None:
+    """Background task: sends emails via SMTP."""
+    result = send_bulk_incident_notification(emails, subject, body_html, body_text)
+    logger.info(
+        "incident.notification.dispatch_complete",
+        extra={"sent": result["sent"], "failed": result["failed"]},
+    )
+
+
+def _body_to_html(subject: str, body: str) -> str:
+    paragraphs = []
+    for line in body.split("\n"):
+        stripped = line.strip()
+        if stripped:
+            paragraphs.append(f"<p style='margin: 0 0 10px 0;'>{stripped}</p>")
+        else:
+            paragraphs.append("<br>")
+
+    body_html_content = "\n".join(paragraphs)
+
+    return f"""
+<html>
+<head></head>
+<body style="font-family: Arial, sans-serif; color: #333; background: #f9f9f9;">
+  <div style="max-width: 600px; margin: 30px auto; background: #fff; border: 1px solid #e0e0e0; border-radius: 8px; padding: 32px;">
+    <h2 style="color: #c0392b; margin-top: 0;">{subject}</h2>
+    <div style="font-size: 15px; line-height: 1.6;">
+      {body_html_content}
+    </div>
+    <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;">
+    <p style="font-size: 12px; color: #999;">
+      Esta mensagem foi enviada em cumprimento ao Art. 48 da Lei nº 13.709/2018 (LGPD).
+    </p>
+  </div>
+</body>
+</html>
+"""

--- a/apps/frontend/src/api/incidentNotification.js
+++ b/apps/frontend/src/api/incidentNotification.js
@@ -1,0 +1,9 @@
+import { adminClient } from "./adminClient";
+
+export function getTemplates() {
+  return adminClient.get("/admin/incident-notification/templates");
+}
+
+export function sendNotification(payload) {
+  return adminClient.post("/admin/incident-notification/send", payload);
+}

--- a/apps/frontend/src/layouts/DashboardLayout.jsx
+++ b/apps/frontend/src/layouts/DashboardLayout.jsx
@@ -15,7 +15,8 @@ import {
   FileSpreadsheet,
   FileArchive,
   Loader2,
-  Users, 
+  Users,
+  ShieldAlert,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "../utils/utils";
@@ -44,6 +45,12 @@ const menuItems = [
     label: "Gestão de Termos",
     href: "/dashboard/termos",
     icon: FileText,
+    allowedProfiles: ["ADMIN"],
+  },
+  {
+    label: "Notificação de Incidente",
+    href: "/dashboard/incident-notification",
+    icon: ShieldAlert,
     allowedProfiles: ["ADMIN"],
   },
 ];

--- a/apps/frontend/src/pages/dashboard/incident-notification/IncidentNotificationPage.jsx
+++ b/apps/frontend/src/pages/dashboard/incident-notification/IncidentNotificationPage.jsx
@@ -1,0 +1,239 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, Loader2, Send, ShieldAlert } from "lucide-react";
+import { toast } from "sonner";
+import { getTemplates, sendNotification } from "@/api/incidentNotification";
+import { cn } from "@/utils/utils";
+
+function ConfirmModal({ open, templateName, onConfirm, onCancel, loading }) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-card border border-border rounded-xl shadow-2xl w-full max-w-md p-6">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 rounded-full bg-destructive/10 flex items-center justify-center shrink-0">
+            <AlertTriangle className="w-5 h-5 text-destructive" />
+          </div>
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Confirmar envio</h2>
+            <p className="text-sm text-muted-foreground">Esta ação não pode ser desfeita.</p>
+          </div>
+        </div>
+
+        <p className="text-sm text-foreground mb-2">
+          Você está prestes a enviar o template{" "}
+          <span className="font-semibold">{templateName}</span> para{" "}
+          <span className="font-semibold">todos os usuários ativos</span> da plataforma.
+        </p>
+        <p className="text-sm text-muted-foreground mb-6">
+          O envio será processado em segundo plano.
+        </p>
+
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 px-4 py-2 text-sm font-medium text-foreground border border-border rounded-lg hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            className="flex-1 px-4 py-2 text-sm font-medium bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Send className="w-4 h-4" />
+            )}
+            {loading ? "Enviando..." : "Confirmar envio"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function IncidentNotificationPage() {
+  const [templates, setTemplates] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    getTemplates()
+      .then((data) => {
+        setTemplates(data);
+        if (data.length > 0) selectTemplate(data[0]);
+      })
+      .catch(() => toast.error("Falha ao carregar os templates."))
+      .finally(() => setLoadingTemplates(false));
+  }, []);
+
+  function selectTemplate(tpl) {
+    setSelectedId(tpl.template_id);
+    setSubject(tpl.subject);
+    setBody(tpl.body);
+  }
+
+  function handleTemplateClick(tpl) {
+    if (tpl.template_id === selectedId) return;
+    selectTemplate(tpl);
+  }
+
+  function handleSendClick() {
+    if (!selectedId) return;
+    setConfirmOpen(true);
+  }
+
+  async function handleConfirm() {
+    setSending(true);
+    const selected = templates.find((t) => t.template_id === selectedId);
+    const payload = {
+      template_id: selectedId,
+      custom_subject: subject === selected?.subject ? undefined : subject,
+      custom_body: body === selected?.body ? undefined : body,
+    };
+
+    try {
+      const result = await sendNotification(payload);
+      const plural = result.recipient_count === 1 ? "" : "s";
+      toast.success(`Notificação agendada para ${result.recipient_count} usuário${plural}.`);
+      setConfirmOpen(false);
+    } catch {
+      toast.error("Falha ao enviar a notificação. Tente novamente.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function handleCancelConfirm() {
+    if (sending) return;
+    setConfirmOpen(false);
+  }
+
+  const selectedTemplate = templates.find((t) => t.template_id === selectedId);
+  const isBodyModified = selectedTemplate && body !== selectedTemplate.body;
+  const isSubjectModified = selectedTemplate && subject !== selectedTemplate.subject;
+  const isModified = isBodyModified || isSubjectModified;
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      {/* Page header */}
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-lg bg-destructive/10 flex items-center justify-center shrink-0">
+          <ShieldAlert className="w-5 h-5 text-destructive" />
+        </div>
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Notificação de Incidente (LGPD Art. 48)</h1>
+          <p className="text-sm text-muted-foreground">
+            Envie comunicados de incidente de segurança a todos os usuários ativos.
+          </p>
+        </div>
+      </div>
+
+      {/* Template selector + editor */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Template list */}
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide px-1">
+            Templates disponíveis
+          </p>
+          {loadingTemplates ? (
+            <div className="flex items-center gap-2 py-4 text-muted-foreground text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Carregando...
+            </div>
+          ) : (
+            templates.map((tpl) => (
+              <button
+                key={tpl.template_id}
+                onClick={() => handleTemplateClick(tpl)}
+                className={cn(
+                  "w-full text-left px-4 py-3 rounded-lg border text-sm transition-colors",
+                  tpl.template_id === selectedId
+                    ? "border-destructive/60 bg-destructive/5 text-foreground"
+                    : "border-border bg-card text-foreground hover:bg-muted",
+                )}
+              >
+                <span className="font-medium">{tpl.name}</span>
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Editor */}
+        <div className="lg:col-span-2 space-y-3">
+          <div className="flex items-center justify-between px-1">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Editar antes de enviar
+            </p>
+            {isModified && (
+              <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">
+                Template modificado
+              </span>
+            )}
+          </div>
+
+          <div className="space-y-3 bg-card border border-border rounded-xl p-4">
+            <div>
+              <label
+                htmlFor="notif-subject"
+                className="block text-xs font-medium text-muted-foreground mb-1"
+              >
+                Assunto
+              </label>
+              <input
+                id="notif-subject"
+                type="text"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                disabled={!selectedId}
+                className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="notif-body"
+                className="block text-xs font-medium text-muted-foreground mb-1"
+              >
+                Corpo da mensagem
+              </label>
+              <textarea
+                id="notif-body"
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                disabled={!selectedId}
+                rows={14}
+                className="w-full px-3 py-2 text-sm border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed resize-y font-mono"
+              />
+            </div>
+
+            <div className="flex justify-end pt-1">
+              <button
+                onClick={handleSendClick}
+                disabled={!selectedId || sending}
+                className="flex items-center gap-2 px-5 py-2.5 text-sm font-medium bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Send className="w-4 h-4" />
+                Enviar notificação
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmModal
+        open={confirmOpen}
+        templateName={selectedTemplate?.name ?? ""}
+        onConfirm={handleConfirm}
+        onCancel={handleCancelConfirm}
+        loading={sending}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/routes/index.jsx
+++ b/apps/frontend/src/routes/index.jsx
@@ -11,6 +11,7 @@ import EstruturaRedesPage from "../pages/dashboard/estrutura-redes-page/Estrutur
 import UsuariosPage from "../pages/dashboard/user-management/UsuariosPage";
 import TermsPage from "../pages/dashboard/terms-management/TermsPage";
 import ProfilePage from "../pages/dashboard/profile/ProfilePage";
+import IncidentNotificationPage from "../pages/dashboard/incident-notification/IncidentNotificationPage";
 
 function NotFoundPage() {
   return (
@@ -37,6 +38,7 @@ export function AppRoutes() {
             <Route path="perfil" element={<ProfilePage />} />
             <Route path="usuarios" element={<RoleRequiredRoute allowedProfiles={["ADMIN","MANAGER"]}><UsuariosPage /></RoleRequiredRoute>} />
             <Route path="termos" element={<RoleRequiredRoute allowedProfiles={["ADMIN"]}><TermsPage /></RoleRequiredRoute>} />
+            <Route path="incident-notification" element={<RoleRequiredRoute allowedProfiles={["ADMIN"]}><IncidentNotificationPage /></RoleRequiredRoute>} />
             <Route path="*" element={<NotFoundPage />} />
           </Route>
         </Route>


### PR DESCRIPTION
## 🔗 Related Issue
> Auto-detected from branch. Confirm or edit if needed.
Branch: feature/466-incident-notification → Issue: #466

Closes #466

## 📝 What was done?
Explain what was implemented and why. Be specific about the approach taken.

Created /dashboard/incident-notification page visible only to the ADMIN profile, with a template selector, subject/body editor, and a mandatory confirmation modal before dispatching
Added 3 pre-written templates compliant with LGPD Art. 48: Cyberattack / Data Breach, Infrastructure Failure / Data Loss, and Accidental Data Exposure
Added GET /admin/incident-notification/templates endpoint to list available templates
Added POST /admin/incident-notification/send endpoint protected by require_admin; returns 202 Accepted immediately and processes the email dispatch in the background to avoid blocking the UI
Dispatch fetches and decrypts EMAIL_ENC for all active users who have completed first access
The dispatch event is recorded via structlog with admin_id, template_id, and recipient_count
Menu item added to DashboardLayout with allowedProfiles: ["ADMIN"] and route protected with RoleRequiredRoute

## 🧪 How to test locally
Step-by-step instructions for the reviewer to validate this PR.
1. Start the environment
docker compose up
2. Log in with an ADMIN user and navigate to "Notificação de Incidente" in the sidebar
3. Select a template, optionally edit the subject/body, and click "Enviar notificação"
4. Confirm in the modal — the response should return 202 with the recipient count
5. Verify the event in the application logs
docker compose logs backend | grep "incident.notification.sent"
 6. Confirm that MANAGER or ANALYST users do not see the menu item
 and receive 403 when attempting to call the endpoint directly
⚠️ Risks and Potential Impact
Describe possible side effects or risks of this change.

Dispatch targets all active users — the confirmation modal is the only safeguard against accidental sends
If SMTP variables are not configured, the send is silently skipped (behavior inherited from the existing email_service); 202 is still returned
No impact on existing tables or migrations

## 📸 Evidence
<img width="1822" height="793" alt="image" src="https://github.com/user-attachments/assets/685d261c-62c9-4d2b-93de-3fc2ec90e55e" />

## ✅ Definition of Done

- [x]  All acceptance criteria from the issue are met
- [x]  Code reviewed before submitting

 
## ✅ Final Checklist

- [x]  My code follows the project style guide
- [x]  I reviewed my own code before submitting
- [x]  I added comments for complex or non-obvious code
- [x]  Documentation updated if needed
- [x]  My changes do not generate new warnings
- [x]  New and existing tests pass with my changes