### PR TITLE
feature/467 Implement rate limiting and logout functionality with tests

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -1,5 +1,8 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
+from slowapi.errors import RateLimitExceeded
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from src.config.middleware import setup_middleware
 from src.config.exception_handlers import (
@@ -7,6 +10,7 @@ from src.config.exception_handlers import (
     unhandled_exception_handler,
     validation_exception_handler,
 )
+from src.config.rate_limiter import limiter
 from src.api.routes import decfec
 from src.api.routes import energy_losses
 from src.api.routes import network_structure
@@ -25,8 +29,19 @@ from src.api.routes import predictions
 from src.config.lifespan import lifespan
 
 app = FastAPI(lifespan=lifespan)
+app.state.limiter = limiter
 
 setup_middleware(app)
+
+
+def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    return JSONResponse(
+        status_code=429,
+        content={"detail": "too_many_requests", "message": f"Rate limit exceeded: {exc.detail}"},
+    )
+
+
+app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 
 app.include_router(decfec.router)
 app.include_router(energy_losses.router)

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -21,3 +21,4 @@ cryptography
 pydantic[email]
 pytest
 PyJWT==2.10.1
+slowapi==0.1.9

--- a/apps/backend/src/api/routes/auth.py
+++ b/apps/backend/src/api/routes/auth.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request, Response
 
+from src.api.dependencies.auth import AuthenticatedUser, get_current_user_no_consent_check
 from src.api.schemas.user_schemas import (
     FirstAccessRequest,
     FirstAccessResponse,
@@ -12,11 +13,13 @@ from src.api.schemas.user_schemas import (
     ResetPasswordRequest,
     ResetPasswordResponse,
 )
+from src.config.rate_limiter import limiter
 from src.database.postgres import get_pg_connection
 from src.services.auth_service import (
     first_access,
     forgot_password,
     login,
+    logout,
     refresh_access_token,
     reset_password,
 )
@@ -26,7 +29,8 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @router.post("/first-access", response_model=FirstAccessResponse)
-def post_first_access(payload: FirstAccessRequest, request: Request):
+@limiter.limit("5/minute")
+def post_first_access(request: Request, payload: FirstAccessRequest):
     source_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "unknown")
 
@@ -40,7 +44,8 @@ def post_first_access(payload: FirstAccessRequest, request: Request):
 
 
 @router.post("/login", response_model=LoginResponse)
-def post_login(payload: LoginRequest, request: Request):
+@limiter.limit("10/minute")
+def post_login(request: Request, payload: LoginRequest):
     source_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "unknown")
 
@@ -51,6 +56,16 @@ def post_login(payload: LoginRequest, request: Request):
             source_ip=source_ip,
             user_agent=user_agent,
         )
+
+
+@router.post("/logout", status_code=204)
+def post_logout(
+    request: Request,
+    current_user: AuthenticatedUser = Depends(get_current_user_no_consent_check),
+):
+    with get_pg_connection() as conn:
+        logout(conn, user_id=current_user.user_id)
+    return Response(status_code=204)
 
 
 @router.post("/refresh", response_model=RefreshTokenResponse)

--- a/apps/backend/src/config/rate_limiter.py
+++ b/apps/backend/src/config/rate_limiter.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/apps/backend/src/repositories/user_repository.py
+++ b/apps/backend/src/repositories/user_repository.py
@@ -631,6 +631,19 @@ def get_user_auth_by_id(conn: PgConnection, user_uuid: str):
     }
 
 
+def invalidate_user_sessions(conn: PgConnection, user_id: str) -> None:
+    query = """
+        UPDATE TB_SESSION
+        SET INVALIDATED_AT = NOW(),
+            UPDATED_AT = NOW()
+        WHERE USER_ID = %s
+          AND INVALIDATED_AT IS NULL
+    """
+
+    with conn.cursor() as cursor:
+        cursor.execute(query, (user_id,))
+
+
 def create_user_session(
     conn: PgConnection,
     *,
@@ -641,16 +654,7 @@ def create_user_session(
     refresh_token_hash: str,
     refresh_expires_at,
 ) -> str:
-    invalidate_query = """
-        UPDATE TB_SESSION
-        SET INVALIDATED_AT = NOW(),
-            UPDATED_AT = NOW()
-        WHERE USER_ID = %s
-          AND INVALIDATED_AT IS NULL
-    """
-
-    with conn.cursor() as cursor:
-        cursor.execute(invalidate_query, (user_id,))
+    invalidate_user_sessions(conn, user_id)
 
     insert_query = """
         INSERT INTO TB_SESSION (

--- a/apps/backend/src/services/auth_service.py
+++ b/apps/backend/src/services/auth_service.py
@@ -28,6 +28,7 @@ from src.repositories.user_repository import (
     create_user_session,
     get_user_auth_by_email_hash,
     get_valid_password_reset_token,
+    invalidate_user_sessions,
     mark_password_reset_token_used,
     rotate_refresh_token,
     update_user_password,
@@ -221,6 +222,10 @@ def login(
         user_agent=user_agent,
         username=user["username"],
     )
+
+
+def logout(conn, *, user_id: str) -> None:
+    invalidate_user_sessions(conn, user_id)
 
 
 def forgot_password(conn, *, email: str) -> ForgotPasswordResponse:

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -22,6 +22,12 @@ def pytest_configure(config):
     except ImportError:
         pass
 
+    # src/config/__init__.py imports setup_middleware at package level, which
+    # triggers pending_consent_middleware → user_repository circular import.
+    # Pre-populate sys.modules so the package __init__ is a no-op during tests.
+    sys.modules.setdefault("src.config.middleware", MagicMock())
+    sys.modules.setdefault("src.config.pending_consent_middleware", MagicMock())
+
 
 @pytest.fixture
 def mock_mongo_client(monkeypatch):

--- a/apps/backend/tests/test_auth_logout.py
+++ b/apps/backend/tests/test_auth_logout.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for server-side logout.
+
+After logout, the same access token must be rejected because the session
+is marked INVALIDATED_AT = NOW() in TB_SESSION.
+"""
+
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+
+def _make_conn():
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__ = lambda s: s
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+class TestInvalidateUserSessions:
+    def test_executes_update_on_active_sessions(self):
+        from src.repositories.user_repository import invalidate_user_sessions
+
+        conn = _make_conn()
+        cursor = conn.cursor.return_value
+
+        invalidate_user_sessions(conn, "user-123")
+
+        cursor.execute.assert_called_once()
+        sql, params = cursor.execute.call_args.args
+        assert "INVALIDATED_AT" in sql
+        assert params == ("user-123",)
+
+    def test_create_user_session_calls_invalidate_first(self):
+        from src.repositories.user_repository import create_user_session, invalidate_user_sessions
+
+        with patch(
+            "src.repositories.user_repository.invalidate_user_sessions"
+        ) as mock_invalidate:
+            conn = _make_conn()
+            cursor = conn.cursor.return_value
+            fake_uuid = "550e8400-e29b-41d4-a716-446655440000"
+            cursor.fetchone.return_value = (fake_uuid,)
+
+            create_user_session(
+                conn,
+                user_id="user-123",
+                source_ip="127.0.0.1",
+                user_agent="test-agent",
+                expires_at=None,
+                refresh_token_hash="hash",
+                refresh_expires_at=None,
+            )
+
+        mock_invalidate.assert_called_once_with(conn, "user-123")
+
+
+class TestLogoutService:
+    def test_logout_invalidates_sessions(self):
+        from src.services.auth_service import logout
+
+        with patch(
+            "src.services.auth_service.invalidate_user_sessions"
+        ) as mock_invalidate:
+            conn = _make_conn()
+            logout(conn, user_id="user-abc")
+
+        mock_invalidate.assert_called_once_with(conn, "user-abc")
+
+
+class TestGetActiveSessionAfterInvalidation:
+    def test_invalidated_session_returns_none(self):
+        from src.repositories.user_repository import get_active_session_user
+
+        conn = _make_conn()
+        cursor = conn.cursor.return_value
+
+        # Row with INVALIDATED_AT set (index 5 is not None)
+        cursor.fetchone.return_value = (
+            "session-uuid",   # SESSION_UUID
+            "user-uuid",      # USER_UUID
+            True,             # ACTIVE
+            True,             # FIRST_ACCESS_COMPLETED
+            "OPERATOR",       # PROFILE_NAME
+            "2024-01-01",     # INVALIDATED_AT — not None → session is invalid
+            None,             # EXPIRES_AT
+            None,             # DELETED_AT
+            None,             # user_deleted_at
+        )
+
+        result = get_active_session_user(conn, "session-uuid")
+
+        assert result is None


### PR DESCRIPTION
## 🔗 Related Issue

Branch: `feature/467-implement-server-side-logout-and-brute-force-protection` → Issue: #467

Closes #467

---

## 📝 What was done?

- Extracted `invalidate_user_sessions(conn, user_id)` as a reusable function in `user_repository.py`, previously inlined inside `create_user_session`.
- Added `logout(conn, user_id)` service function in `auth_service.py`.
- Implemented `POST /auth/logout` in `auth.py`, protected by `get_current_user_no_consent_check`, invalidates the active session by setting `INVALIDATED_AT = NOW()` in `TB_SESSION` and returns HTTP 204 No Content.
- Added rate limiting via `slowapi` (in-memory, no external dependency):
  - `POST /auth/login` → 10 requests/minute per IP
  - `POST /auth/first-access` → 5 requests/minute per IP
- Rate limit violations return HTTP 429 with `{"detail": "too_many_requests", "message": "..."}`.
- Added `slowapi==0.1.9` to `requirements.txt`.
- Created `src/config/rate_limiter.py` with the shared `Limiter` instance.
- Registered the rate limit exception handler in `main.py`.
- Added unit tests covering:
  - `invalidate_user_sessions` executes the correct SQL
  - `create_user_session` calls `invalidate_user_sessions` first
  - `logout` service calls `invalidate_user_sessions`
  - `get_active_session_user` returns `None` for an invalidated session

---

## 🧪 How to test locally

```bash
# 1. Start the environment
docker compose up

# 2. Run the unit tests
docker compose exec backend python -m pytest tests/test_auth_logout.py -v

# 3. Login with any user and copy the access token

# 4. Call POST /auth/logout with the token
curl -X POST http://localhost:8000/auth/logout \
  -H "Authorization: Bearer <access_token>"
# Expected: 204 No Content

# 5. Reuse the same token on any protected endpoint
curl http://localhost:8000/users/me \
  -H "Authorization: Bearer <access_token>"
# Expected: 401 invalid_or_expired_session

# 6. Validate rate limiting on login
for i in $(seq 1 12); do
  curl -s -o /dev/null -w "%{http_code}\n" \
    -X POST http://localhost:8000/auth/login \
    -H "Content-Type: application/json" \
    -d '{"email":"test@test.com","password":"wrong"}'
done
# Expected: first 10 return 401, from the 11th onward return 429
Optional validation:

# Backend syntax check
python -m py_compile apps/backend/main.py \
  apps/backend/src/api/routes/auth.py \
  apps/backend/src/config/rate_limiter.py \
  apps/backend/src/repositories/user_repository.py \
  apps/backend/src/services/auth_service.py

# Unit tests
docker compose exec backend python -m pytest tests/test_auth_logout.py -v
⚠️ Risks and Potential Impact
Rate limiting is in-memory (slowapi default MemoryStorage). Counters reset on server restart and are not shared between workers. Adequate for single-worker deployments; a distributed store (Redis) would be needed for multi-worker setups.
POST /auth/logout invalidates all active sessions for the user, not only the one matching the current token. This is intentional: on login, create_user_session already invalidates all prior sessions, so the behavior is consistent.
No changes to existing login, refresh, or consent flows.
```

## 📸 Evidence
<img width="650" height="631" alt="image" src="https://github.com/user-attachments/assets/698614bd-a4f9-4bd0-977f-89891aa38593" />

## ✅ Definition of Done

- [x]  All acceptance criteria from the issue are met
- [x]  Code reviewed before submitting

## ✅ Final Checklist

- [x]  My code follows the project style guide
- [x]  I reviewed my own code before submitting
- [x]  I added comments for complex or non-obvious code
- [x]  Documentation updated if needed
- [x]  My changes do not generate new warnings
- [x]  New and existing tests pass with my changes