### PR TITLE
Feature/449 hover tooltip on polygons

### DIFF
--- a/apps/frontend/src/components/heatmap.jsx
+++ b/apps/frontend/src/components/heatmap.jsx
@@ -50,13 +50,13 @@ export function Heatmap({ convertedConjs }) {
             return (
                 <Polygon pathOptions={defineColor(conj)} positions={coordinates}>
                      <Tooltip>
-                        Name: {conj.name}
+                        Name: {conj.name ? conj.name : "-"}
                         <br />
-                        Indicator Type: {conj.indicator_type_code}
+                        Indicator Type: {conj.indicator_type_code ? conj.indicator_type_code : "-"}
                         <br />
-                        Limit: {conj.limit}
+                        Limit: {conj.limit ? conj.limit : "-"}
                         <br />
-                        Accumulated Value: {conj.accumulated_value}
+                        Accumulated Value: {conj.accumulated_value ? conj.accumulated_value : "-"}
                      </Tooltip>
                 </Polygon>
             )

--- a/apps/frontend/src/components/heatmap.jsx
+++ b/apps/frontend/src/components/heatmap.jsx
@@ -10,7 +10,7 @@ import {
 import "../App.css"
 import "@/index.css" // Ensure base classes are present if needed
 import "leaflet/dist/leaflet.css";
-import { MapContainer, TileLayer, Marker, Popup, Polygon } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Popup, Polygon, Tooltip } from 'react-leaflet'
 
 export function Heatmap({ convertedConjs }) {
 
@@ -45,10 +45,22 @@ export function Heatmap({ convertedConjs }) {
 
     function mappedPolygons(conj) {
         if (conj.coordinates) {
-            let coordinates = conj.coordinates
+            // let coordinates = conj.coordinates
+            let {coordinates, ...rest} = conj
             coordinates = invertCoordinates(coordinates)
+            let informationString = JSON.stringify(rest)
             return (
-                <Polygon pathOptions={defineColor(conj)} positions={coordinates} />
+                <Polygon pathOptions={defineColor(conj)} positions={coordinates}>
+                     <Tooltip>
+                        Name: {conj.name}
+                        <br />
+                        Indicator Type: {conj.indicator_type_code}
+                        <br />
+                        Limit: {conj.limit}
+                        <br />
+                        Accumulated Value: {conj.accumulated_value}
+                     </Tooltip>
+                </Polygon>
             )
         }
 

--- a/apps/frontend/src/components/heatmap.jsx
+++ b/apps/frontend/src/components/heatmap.jsx
@@ -45,10 +45,8 @@ export function Heatmap({ convertedConjs }) {
 
     function mappedPolygons(conj) {
         if (conj.coordinates) {
-            // let coordinates = conj.coordinates
-            let {coordinates, ...rest} = conj
+            let coordinates = conj.coordinates
             coordinates = invertCoordinates(coordinates)
-            let informationString = JSON.stringify(rest)
             return (
                 <Polygon pathOptions={defineColor(conj)} positions={coordinates}>
                      <Tooltip>

--- a/apps/frontend/src/pages/dashboard/heatmap/HeatmapFilters.jsx
+++ b/apps/frontend/src/pages/dashboard/heatmap/HeatmapFilters.jsx
@@ -500,8 +500,8 @@ export function HeatmapFilters() {
   ]
 
   useEffect(() => {
-    // setConvertedConjs(mockedDataTest);
-    fetchConj()
+    setConvertedConjs(mockedDataTest);
+    // fetchConj()
   }, [])
 
 

--- a/apps/frontend/src/pages/dashboard/heatmap/HeatmapFilters.jsx
+++ b/apps/frontend/src/pages/dashboard/heatmap/HeatmapFilters.jsx
@@ -500,8 +500,8 @@ export function HeatmapFilters() {
   ]
 
   useEffect(() => {
-    setConvertedConjs(mockedDataTest);
-    // fetchConj()
+    // setConvertedConjs(mockedDataTest);
+    fetchConj()
   }, [])
 
 


### PR DESCRIPTION
## 🔗 Related Issue

> Auto-detected from branch. Confirm or edit if needed.
> Branch: `feature/42-description` → Issue: #42

Closes #449

---

## 🏷️ Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs

**Breaking change:** <!-- If checked, describe what breaks and the migration steps -->

---

## 📝 What was done?

> Explain what was implemented and why. Be specific about the approach taken.

- Added tooltip content when hovering trough a specific conj in the heatmap page

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

```bash
# 1. Start the environment
docker compose --profile full --profile tools up

# 2.  Open up http://localhost:5173/ and go to the heatmap page

# 3. Hover over a specific conj
```

---

## 🚀 Deploy Notes

> Migrations, env vars, or infra changes required for this PR.

- [x] No special deploy steps needed
- [ ] Database migration required
- [ ] New environment variable(s) required
- [ ] Infrastructure change required

---

## ⚠️ Risks and Potential Impact

> Describe possible side effects or risks of this change.

- N/A

---

## 📸 Evidence

> Add screenshots, logs or relevant outputs.

- 
<img width="1485" height="926" alt="image" src="https://github.com/user-attachments/assets/64348ede-db00-456f-a5c0-2f933f1322a4" />


---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] New and existing tests pass with my changes

<details>
<summary>✨ Traceability</summary>

**Issue:** #449
**Type:** `feature`
**Branch:** `feature/449-hover-tooltip-on-polygons`

</details>