### PR TITLE
Feat/509 add consent preference management

### DIFF
--- a/apps/backend/src/api/routes/users.py
+++ b/apps/backend/src/api/routes/users.py
@@ -1,33 +1,66 @@
 import structlog
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from typing import List
 from uuid import UUID
 
-from src.api.dependencies.auth import require_admin, require_admin_or_manager
+from src.api.dependencies.auth import (
+    AuthenticatedUser,
+    get_current_user,
+    get_current_user_no_consent_check,
+    require_admin,
+    require_admin_or_manager,
+)
 from src.api.schemas.user_schemas import (
-    ProfileResponse, UserCreateRequest, UserCreateResponse,
-    UserMeResponse, UserMeUpdateRequest, UserResult, UserUpdateRequest, UserSetActiveRequest,
+    ProfileResponse,
+    UserConsentPreferencesResponse,
+    UserConsentUpdateRequest,
+    UserConsentUpdateResponse,
+    UserCreateRequest,
+    UserCreateResponse,
+    UserMeResponse,
+    UserMeUpdateRequest,
+    UserResult,
+    UserSetActiveRequest,
+    UserUpdateRequest,
 )
-from src.api.dependencies.auth import AuthenticatedUser, get_current_user
 from src.config.log_events import (
-    USER_CREATED, USER_UPDATED, USER_DEACTIVATED,
-    USER_DELETED, USER_NOT_FOUND, USER_CONFLICT, USER_LISTED,
+    USER_CREATED,
+    USER_UPDATED,
+    USER_DEACTIVATED,
+    USER_DELETED,
+    USER_NOT_FOUND,
+    USER_CONFLICT,
+    USER_LISTED,
 )
+from src.database.postgres import get_pg_connection, set_current_user
 from src.repositories.user_repository import (
-    ProfilePersistenceError, UserAlreadyExistsError, UserNotFoundError,
-    UserPersistenceError, UserProfileNotFoundError,
+    ProfilePersistenceError,
+    UserAlreadyExistsError,
+    UserNotFoundError,
+    UserPersistenceError,
+    UserProfileNotFoundError,
 )
 from src.services.auth_service import admin_invalidate_user_sessions_service
+from src.services.consent_service import (
+    get_user_consent_preferences,
+    update_user_consent_preferences,
+)
 from src.services.user_service import (
-    create_user_service, list_profiles_service, get_user_by_id_service,
-    list_users_service, update_user_service, set_user_active_service,
-    delete_user_service, get_current_user_profile_service,
+    create_user_service,
+    delete_user_service,
+    get_current_user_profile_service,
+    get_user_by_id_service,
+    list_profiles_service,
+    list_users_service,
+    set_user_active_service,
     update_current_user_profile_service,
+    update_user_service,
 )
 
 router = APIRouter(prefix="/users", tags=["users"])
 log = structlog.get_logger()
+
 
 @router.get("/", response_model=List[UserResult], status_code=status.HTTP_200_OK)
 def list_users(current_user: AuthenticatedUser = Depends(require_admin_or_manager)):
@@ -41,9 +74,15 @@ def get_profiles(_current_user: AuthenticatedUser = Depends(get_current_user)):
     try:
         profiles = list_profiles_service()
         log.info("profiles.listed", count=len(profiles))
-        return [ProfileResponse(profile_uuid=p.profile_uuid, profile_name=p.profile_name) for p in profiles]
+        return [
+            ProfileResponse(profile_uuid=p.profile_uuid, profile_name=p.profile_name)
+            for p in profiles
+        ]
     except ProfilePersistenceError as exc:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Falha ao listar perfis.") from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Falha ao listar perfis.",
+        ) from exc
 
 
 @router.get("/me", response_model=UserMeResponse, status_code=status.HTTP_200_OK)
@@ -76,6 +115,70 @@ def update_my_profile(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
 
+@router.get(
+    "/{user_uuid}/consents",
+    response_model=UserConsentPreferencesResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List current consent preferences for the authenticated user",
+)
+def get_user_consents(
+    user_uuid: UUID,
+    current_user: AuthenticatedUser = Depends(get_current_user_no_consent_check),
+):
+    if str(user_uuid) != current_user.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="cannot_manage_other_user_consents",
+        )
+
+    with get_pg_connection() as conn:
+        set_current_user(conn, current_user.user_id)
+        consents = get_user_consent_preferences(conn, current_user.user_id)
+
+    return {
+        "user_id": current_user.user_id,
+        "consents": consents,
+    }
+
+
+@router.patch(
+    "/{user_uuid}/consents",
+    response_model=UserConsentUpdateResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update consent preferences for the authenticated user",
+    description=(
+        "Updates individual consent preferences. Each change is stored as a new "
+        "append-only TB_CONSENT_LOG event. If a mandatory clause is revoked, the "
+        "user is anonymized and all active sessions are invalidated before the "
+        "response is returned."
+    ),
+)
+def patch_user_consents(
+    user_uuid: UUID,
+    payload: UserConsentUpdateRequest,
+    request: Request,
+    current_user: AuthenticatedUser = Depends(get_current_user_no_consent_check),
+):
+    if str(user_uuid) != current_user.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="cannot_manage_other_user_consents",
+        )
+
+    source_ip = request.client.host if request.client else "unknown"
+    user_agent = request.headers.get("user-agent", "unknown")
+
+    with get_pg_connection() as conn:
+        set_current_user(conn, current_user.user_id)
+        return update_user_consent_preferences(
+            conn,
+            user_id=current_user.user_id,
+            updates=payload.consents,
+            source_ip=source_ip,
+            user_agent=user_agent,
+        )
+
+
 @router.get("/{user_uuid}", response_model=UserResult, status_code=status.HTTP_200_OK)
 def get_user(user_uuid: UUID, current_user: AuthenticatedUser = Depends(require_admin_or_manager)):
     try:
@@ -98,12 +201,20 @@ def create_user(payload: UserCreateRequest, current_user: AuthenticatedUser = De
         log.warning(USER_NOT_FOUND, reason=str(exc))
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except UserPersistenceError as exc:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Falha ao criar usuário.") from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Falha ao criar usuário.",
+        ) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
 
+
 @router.patch("/{user_uuid}", response_model=UserResult, status_code=status.HTTP_200_OK)
-def update_user(user_uuid: UUID, payload: UserUpdateRequest, current_user: AuthenticatedUser = Depends(require_admin)):
+def update_user(
+    user_uuid: UUID,
+    payload: UserUpdateRequest,
+    current_user: AuthenticatedUser = Depends(require_admin),
+):
     try:
         data = {"username": payload.username, "profile_id": payload.profile_id}
         result = update_user_service(user_uuid, data)
@@ -144,6 +255,7 @@ def delete_user_sessions(
         target_user_id=str(user_uuid),
         acting_user_id=current_user.user_id,
     )
+
 
 @router.delete("/{user_uuid}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_user(user_uuid: UUID, current_user: AuthenticatedUser = Depends(require_admin)):

--- a/apps/backend/src/api/schemas/user_schemas.py
+++ b/apps/backend/src/api/schemas/user_schemas.py
@@ -76,20 +76,6 @@ class MyProfileUpdateRequest(BaseModel):
         return str(v).strip().lower()
 
 
-class MyProfileResponse(UserResult):
-    email: EmailStr
-    profile_name: str
-
-
-class MyProfileUpdateRequest(BaseModel):
-    username: str = Field(..., min_length=3, max_length=50)
-    email: EmailStr
-
-    @field_validator("email")
-    def normalize_email(cls, v: EmailStr) -> str:
-        return str(v).strip().lower()
-
-
 class UserUpdateRequest(BaseModel):
     username: str = Field(..., min_length=3, max_length=50)
     profile_id: UUID
@@ -115,28 +101,44 @@ class UserMeUpdateRequest(BaseModel):
         return str(v).strip().lower()
 
 
-class UserMeResponse(BaseModel):
-    user_uuid: UUID
-    username: str
-    email: EmailStr
-    profile_name: str
-    active: bool
-    first_access_completed: bool
-    created_at: datetime
-    updated_at: datetime
-
-
-class UserMeUpdateRequest(BaseModel):
-    username: str = Field(..., min_length=3, max_length=50)
-    email: EmailStr
-
-    @field_validator("email")
-    def normalize_email(cls, v: EmailStr) -> str:
-        return str(v).strip().lower()
-
-
 class UserSetActiveRequest(BaseModel):
     active: bool
+
+
+class UserConsentUpdateItem(BaseModel):
+    clause_id: UUID
+    accepted: bool
+
+
+class UserConsentUpdateRequest(BaseModel):
+    consents: list[UserConsentUpdateItem] = Field(..., min_length=1)
+
+
+class UserConsentPreferenceItem(BaseModel):
+    clause_id: UUID
+    policy_version_id: UUID
+    policy_type: str
+    policy_version: str
+    clause_code: str
+    clause_title: str
+    clause_description: str | None = None
+    mandatory: bool
+    accepted: bool
+    current_status: str
+    last_action: str | None = None
+    last_action_at: datetime | None = None
+
+
+class UserConsentPreferencesResponse(BaseModel):
+    user_id: UUID
+    consents: list[UserConsentPreferenceItem]
+
+
+class UserConsentUpdateResponse(BaseModel):
+    account_deleted: bool
+    updated_count: int
+    consents: list[UserConsentPreferenceItem] | None = None
+
 
 class CurrentUserResponse(BaseModel):
     user_id: UUID
@@ -144,6 +146,7 @@ class CurrentUserResponse(BaseModel):
     profile: str
     first_access_completed: bool
     active: bool
+
 
 class LoginRequest(BaseModel):
     email: EmailStr
@@ -188,8 +191,10 @@ class RefreshTokenResponse(BaseModel):
     refresh_token: str
     token_type: str = "bearer"
 
+
 class LogoutResponse(BaseModel):
     detail: str
+
 
 class ForgotPasswordRequest(BaseModel):
     email: EmailStr

--- a/apps/backend/src/repositories/anonymization_repository.py
+++ b/apps/backend/src/repositories/anonymization_repository.py
@@ -1,0 +1,33 @@
+from psycopg2.extensions import connection as PgConnection
+
+
+def anonymize_user(conn: PgConnection, user_uuid: str) -> bool:
+    """
+    Anonymizes a user after mandatory consent revocation.
+
+    USER_UUID is preserved as a technical non-identifying anchor so consent logs
+    and foreign keys remain valid, while personal identifiers are replaced.
+    """
+    query = """
+        UPDATE TB_USER
+        SET USERNAME = CONCAT('anonymized_', REPLACE(USER_UUID::TEXT, '-', '')),
+            EMAIL_HASH = CONCAT('anon_', REPLACE(USER_UUID::TEXT, '-', '')),
+            EMAIL_ENC = '[removed]',
+            PASSWORD_HASH = '[removed]',
+            KEYCLOAK_SUB = NULL,
+            ACTIVE = FALSE,
+            FIRST_ACCESS_COMPLETED = FALSE,
+            ANONYMIZED_AT = NOW(),
+            DELETED_AT = NOW(),
+            UPDATED_AT = NOW()
+        WHERE USER_UUID = %s
+          AND ANONYMIZED_AT IS NULL
+          AND DELETED_AT IS NULL
+        RETURNING USER_UUID
+    """
+
+    with conn.cursor() as cursor:
+        cursor.execute(query, (str(user_uuid),))
+        row = cursor.fetchone()
+
+    return row is not None

--- a/apps/backend/src/repositories/consent_repository.py
+++ b/apps/backend/src/repositories/consent_repository.py
@@ -139,6 +139,107 @@ def list_current_mandatory_clauses(conn) -> list[dict]:
         return cur.fetchall()
 
 
+def list_user_current_consent_preferences(conn, user_id: str) -> list[dict]:
+    """
+    Lists all current policy clauses and their latest consent state for one user.
+    """
+    with dict_cursor(conn) as cur:
+        cur.execute(
+            """
+            WITH current_versions AS (
+                SELECT
+                    pv.VERSION_UUID,
+                    pv.VERSION,
+                    pv.POLICY_TYPE,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY pv.POLICY_TYPE
+                        ORDER BY pv.EFFECTIVE_FROM DESC, pv.CREATED_AT DESC
+                    ) AS rn
+                FROM TB_POLICY_VERSION pv
+                WHERE pv.DELETED_AT IS NULL
+                  AND pv.EFFECTIVE_FROM <= NOW()
+            )
+            SELECT
+                c.CLAUSE_UUID AS clause_uuid,
+                c.POLICY_VERSION_ID AS policy_version_id,
+                pv.POLICY_TYPE AS policy_type,
+                pv.VERSION AS policy_version,
+                c.CODE AS clause_code,
+                c.TITLE AS clause_title,
+                c.DESCRIPTION AS clause_description,
+                c.MANDATORY AS mandatory,
+                last_log.ACTION AS last_action,
+                last_log.CREATED_AT AS last_action_at,
+                CASE
+                    WHEN last_log.ACTION IN ('CONSENT', 'CONSENT_ACCEPTED') THEN TRUE
+                    ELSE FALSE
+                END AS accepted,
+                COALESCE(last_log.ACTION, 'PENDING') AS current_status
+            FROM TB_POLICY_CLAUSE c
+            JOIN current_versions pv
+              ON pv.VERSION_UUID = c.POLICY_VERSION_ID
+             AND pv.rn = 1
+            LEFT JOIN LATERAL (
+                SELECT
+                    cl.ACTION,
+                    cl.CREATED_AT
+                FROM TB_CONSENT_LOG cl
+                WHERE cl.USER_ID = %s
+                  AND cl.CLAUSE_ID = c.CLAUSE_UUID
+                ORDER BY cl.CREATED_AT DESC, cl.LOG_UUID DESC
+                LIMIT 1
+            ) last_log ON TRUE
+            WHERE c.DELETED_AT IS NULL
+            ORDER BY pv.POLICY_TYPE, pv.VERSION, c.DISPLAY_ORDER
+            """,
+            (user_id,),
+        )
+
+        return cur.fetchall()
+
+
+def get_current_clause_for_consent_update(conn, clause_id: str) -> dict | None:
+    """
+    Resolves a clause from the current effective policy versions.
+    """
+    with dict_cursor(conn) as cur:
+        cur.execute(
+            """
+            WITH current_versions AS (
+                SELECT
+                    pv.VERSION_UUID,
+                    pv.POLICY_TYPE,
+                    pv.VERSION,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY pv.POLICY_TYPE
+                        ORDER BY pv.EFFECTIVE_FROM DESC, pv.CREATED_AT DESC
+                    ) AS rn
+                FROM TB_POLICY_VERSION pv
+                WHERE pv.DELETED_AT IS NULL
+                  AND pv.EFFECTIVE_FROM <= NOW()
+            )
+            SELECT
+                c.CLAUSE_UUID AS clause_uuid,
+                c.POLICY_VERSION_ID AS policy_version_id,
+                c.MANDATORY AS mandatory,
+                c.CODE AS code,
+                c.TITLE AS title,
+                pv.POLICY_TYPE AS policy_type,
+                pv.VERSION AS version
+            FROM TB_POLICY_CLAUSE c
+            JOIN current_versions pv
+              ON pv.VERSION_UUID = c.POLICY_VERSION_ID
+             AND pv.rn = 1
+            WHERE c.CLAUSE_UUID = %s
+              AND c.DELETED_AT IS NULL
+            LIMIT 1
+            """,
+            (clause_id,),
+        )
+
+        return cur.fetchone()
+
+
 def insert_consent_event(
     conn,
     user_id: str,

--- a/apps/backend/src/services/consent_service.py
+++ b/apps/backend/src/services/consent_service.py
@@ -8,9 +8,12 @@ from psycopg2 import IntegrityError, OperationalError
 
 from src.config.exception_handlers import handle_db_integrity_error, handle_db_operational_error
 from src.repositories import consent_repository
+from src.repositories.anonymization_repository import anonymize_user
+from src.repositories.user_repository import invalidate_user_sessions
 from src.config.log_events import  CONSENT_REGISTERED, CONSENT_REVOKED
 
 log = structlog.get_logger()
+
 
 @dataclass
 class AuthenticatedUser:
@@ -119,6 +122,146 @@ def get_user_consent_history(conn, user_id: str) -> list[dict]:
         raise HTTPException(status_code=503, detail="database_unavailable")
 
     return format_consent_history(rows)
+
+
+def format_consent_preferences(rows: list[dict]) -> list[dict]:
+    return [
+        {
+            "clause_id": row["clause_uuid"],
+            "policy_version_id": row["policy_version_id"],
+            "policy_type": row["policy_type"],
+            "policy_version": row["policy_version"],
+            "clause_code": row["clause_code"],
+            "clause_title": row["clause_title"],
+            "clause_description": row.get("clause_description"),
+            "mandatory": row["mandatory"],
+            "accepted": row["accepted"],
+            "current_status": row["current_status"],
+            "last_action": row.get("last_action"),
+            "last_action_at": row.get("last_action_at"),
+        }
+        for row in rows
+    ]
+
+
+def get_user_consent_preferences(conn, user_id: str) -> list[dict]:
+    """
+    Returns all current clauses with the latest consent status for the user.
+    """
+    try:
+        rows = consent_repository.list_user_current_consent_preferences(conn, user_id)
+    except IntegrityError as exc:
+        handle_db_integrity_error(exc, context="get_user_consent_preferences")
+        raise HTTPException(status_code=409, detail="conflict")
+    except OperationalError as exc:
+        handle_db_operational_error(exc, context="get_user_consent_preferences")
+        raise HTTPException(status_code=503, detail="database_unavailable")
+
+    return format_consent_preferences(rows)
+
+
+def update_user_consent_preferences(
+    conn,
+    *,
+    user_id: str,
+    updates: list,
+    source_ip: str,
+    user_agent: str,
+) -> dict:
+    """
+    Updates consent preferences after onboarding.
+
+    Every change is recorded as a new append-only TB_CONSENT_LOG row.
+    Revoking a mandatory clause anonymizes the user and invalidates all active
+    sessions before the response is returned.
+    """
+    if not updates:
+        raise HTTPException(status_code=422, detail="empty_consent_update")
+
+    seen_clause_ids = set()
+    mandatory_revoked = False
+    updated_count = 0
+
+    try:
+        for item in updates:
+            clause_id = str(item.clause_id)
+
+            if clause_id in seen_clause_ids:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "code": "duplicate_clause_id",
+                        "clause_id": clause_id,
+                    },
+                )
+
+            seen_clause_ids.add(clause_id)
+
+            clause = consent_repository.get_current_clause_for_consent_update(
+                conn,
+                clause_id,
+            )
+
+            if not clause:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "code": "invalid_clause_id",
+                        "clause_id": clause_id,
+                    },
+                )
+
+            accepted = bool(item.accepted)
+            event_action = "CONSENT_ACCEPTED" if accepted else "CONSENT_REVOKED"
+
+            inserted = consent_repository.insert_consent_event(
+                conn=conn,
+                user_id=user_id,
+                clause_uuid=str(clause["clause_uuid"]),
+                policy_version_id=str(clause["policy_version_id"]),
+                event_action=event_action,
+                source_ip=source_ip,
+                user_agent=user_agent,
+            )
+
+            if not inserted:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "code": "consent_event_not_inserted",
+                        "clause_id": clause_id,
+                    },
+                )
+
+            updated_count += 1
+
+            if clause["mandatory"] and not accepted:
+                mandatory_revoked = True
+
+        if mandatory_revoked:
+            anonymize_user(conn, user_id)
+            invalidate_user_sessions(conn, user_id)
+
+            return {
+                "account_deleted": True,
+                "updated_count": updated_count,
+                "consents": None,
+            }
+
+        return {
+            "account_deleted": False,
+            "updated_count": updated_count,
+            "consents": get_user_consent_preferences(conn, user_id),
+        }
+
+    except HTTPException:
+        raise
+    except IntegrityError as exc:
+        handle_db_integrity_error(exc, context="update_user_consent_preferences")
+        raise HTTPException(status_code=409, detail="conflict")
+    except OperationalError as exc:
+        handle_db_operational_error(exc, context="update_user_consent_preferences")
+        raise HTTPException(status_code=503, detail="database_unavailable")
 
 
 def _get_action_value(action_item) -> str:

--- a/apps/backend/tests/test_user_consent_management.py
+++ b/apps/backend/tests/test_user_consent_management.py
@@ -1,0 +1,262 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from src.api.dependencies.auth import AuthenticatedUser, get_current_user_no_consent_check
+from src.api.routes import users
+from src.services.consent_service import update_user_consent_preferences
+
+
+class ConsentUpdateItem:
+    def __init__(self, clause_id, accepted):
+        self.clause_id = clause_id
+        self.accepted = accepted
+
+
+def test_optional_consent_revocation_only_logs_event():
+    conn = MagicMock()
+    user_id = str(uuid4())
+    clause_id = str(uuid4())
+    policy_version_id = str(uuid4())
+
+    with patch(
+        "src.services.consent_service.consent_repository.get_current_clause_for_consent_update",
+        return_value={
+            "clause_uuid": clause_id,
+            "policy_version_id": policy_version_id,
+            "mandatory": False,
+        },
+    ), patch(
+        "src.services.consent_service.consent_repository.insert_consent_event",
+        return_value=True,
+    ) as mock_insert, patch(
+        "src.services.consent_service.anonymize_user"
+    ) as mock_anonymize, patch(
+        "src.services.consent_service.invalidate_user_sessions"
+    ) as mock_invalidate, patch(
+        "src.services.consent_service.get_user_consent_preferences",
+        return_value=[],
+    ):
+        result = update_user_consent_preferences(
+            conn,
+            user_id=user_id,
+            updates=[ConsentUpdateItem(clause_id, False)],
+            source_ip="127.0.0.1",
+            user_agent="pytest",
+        )
+
+    assert result == {
+        "account_deleted": False,
+        "updated_count": 1,
+        "consents": [],
+    }
+    mock_insert.assert_called_once()
+    assert mock_insert.call_args.kwargs["event_action"] == "CONSENT_REVOKED"
+    mock_anonymize.assert_not_called()
+    mock_invalidate.assert_not_called()
+
+
+def test_optional_consent_acceptance_only_logs_event():
+    conn = MagicMock()
+    user_id = str(uuid4())
+    clause_id = str(uuid4())
+    policy_version_id = str(uuid4())
+
+    with patch(
+        "src.services.consent_service.consent_repository.get_current_clause_for_consent_update",
+        return_value={
+            "clause_uuid": clause_id,
+            "policy_version_id": policy_version_id,
+            "mandatory": False,
+        },
+    ), patch(
+        "src.services.consent_service.consent_repository.insert_consent_event",
+        return_value=True,
+    ) as mock_insert, patch(
+        "src.services.consent_service.anonymize_user"
+    ) as mock_anonymize, patch(
+        "src.services.consent_service.invalidate_user_sessions"
+    ) as mock_invalidate, patch(
+        "src.services.consent_service.get_user_consent_preferences",
+        return_value=[],
+    ):
+        result = update_user_consent_preferences(
+            conn,
+            user_id=user_id,
+            updates=[ConsentUpdateItem(clause_id, True)],
+            source_ip="127.0.0.1",
+            user_agent="pytest",
+        )
+
+    assert result["account_deleted"] is False
+    assert result["updated_count"] == 1
+    assert result["consents"] == []
+    assert mock_insert.call_args.kwargs["event_action"] == "CONSENT_ACCEPTED"
+    mock_anonymize.assert_not_called()
+    mock_invalidate.assert_not_called()
+
+
+def test_mandatory_consent_revocation_anonymizes_and_invalidates_sessions():
+    conn = MagicMock()
+    user_id = str(uuid4())
+    clause_id = str(uuid4())
+    policy_version_id = str(uuid4())
+
+    with patch(
+        "src.services.consent_service.consent_repository.get_current_clause_for_consent_update",
+        return_value={
+            "clause_uuid": clause_id,
+            "policy_version_id": policy_version_id,
+            "mandatory": True,
+        },
+    ), patch(
+        "src.services.consent_service.consent_repository.insert_consent_event",
+        return_value=True,
+    ) as mock_insert, patch(
+        "src.services.consent_service.anonymize_user",
+        return_value=True,
+    ) as mock_anonymize, patch(
+        "src.services.consent_service.invalidate_user_sessions",
+        return_value=True,
+    ) as mock_invalidate:
+        result = update_user_consent_preferences(
+            conn,
+            user_id=user_id,
+            updates=[ConsentUpdateItem(clause_id, False)],
+            source_ip="127.0.0.1",
+            user_agent="pytest",
+        )
+
+    assert result == {
+        "account_deleted": True,
+        "updated_count": 1,
+        "consents": None,
+    }
+    assert mock_insert.call_args.kwargs["event_action"] == "CONSENT_REVOKED"
+    mock_anonymize.assert_called_once_with(conn, user_id)
+    mock_invalidate.assert_called_once_with(conn, user_id)
+
+
+def test_mandatory_consent_acceptance_does_not_delete_account():
+    conn = MagicMock()
+    user_id = str(uuid4())
+    clause_id = str(uuid4())
+    policy_version_id = str(uuid4())
+
+    with patch(
+        "src.services.consent_service.consent_repository.get_current_clause_for_consent_update",
+        return_value={
+            "clause_uuid": clause_id,
+            "policy_version_id": policy_version_id,
+            "mandatory": True,
+        },
+    ), patch(
+        "src.services.consent_service.consent_repository.insert_consent_event",
+        return_value=True,
+    ), patch(
+        "src.services.consent_service.anonymize_user"
+    ) as mock_anonymize, patch(
+        "src.services.consent_service.invalidate_user_sessions"
+    ) as mock_invalidate, patch(
+        "src.services.consent_service.get_user_consent_preferences",
+        return_value=[],
+    ):
+        result = update_user_consent_preferences(
+            conn,
+            user_id=user_id,
+            updates=[ConsentUpdateItem(clause_id, True)],
+            source_ip="127.0.0.1",
+            user_agent="pytest",
+        )
+
+    assert result["account_deleted"] is False
+    assert result["updated_count"] == 1
+    mock_anonymize.assert_not_called()
+    mock_invalidate.assert_not_called()
+
+
+def test_invalid_clause_returns_422():
+    conn = MagicMock()
+
+    with patch(
+        "src.services.consent_service.consent_repository.get_current_clause_for_consent_update",
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            update_user_consent_preferences(
+                conn,
+                user_id=str(uuid4()),
+                updates=[ConsentUpdateItem(str(uuid4()), True)],
+                source_ip="127.0.0.1",
+                user_agent="pytest",
+            )
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail["code"] == "invalid_clause_id"
+
+
+def test_duplicate_clause_id_returns_422():
+    conn = MagicMock()
+    clause_id = str(uuid4())
+
+    with patch(
+        "src.services.consent_service.consent_repository.get_current_clause_for_consent_update",
+        return_value={
+            "clause_uuid": clause_id,
+            "policy_version_id": str(uuid4()),
+            "mandatory": False,
+        },
+    ), patch(
+        "src.services.consent_service.consent_repository.insert_consent_event",
+        return_value=True,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            update_user_consent_preferences(
+                conn,
+                user_id=str(uuid4()),
+                updates=[
+                    ConsentUpdateItem(clause_id, True),
+                    ConsentUpdateItem(clause_id, False),
+                ],
+                source_ip="127.0.0.1",
+                user_agent="pytest",
+            )
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail["code"] == "duplicate_clause_id"
+
+
+def test_user_cannot_update_another_users_consents():
+    current_user_id = str(uuid4())
+    other_user_id = str(uuid4())
+
+    app = FastAPI()
+    app.include_router(users.router)
+    app.dependency_overrides[get_current_user_no_consent_check] = lambda: AuthenticatedUser(
+        user_id=current_user_id,
+        session_id=str(uuid4()),
+        username="regular_user",
+        profile_name="USER",
+        first_access_completed=True,
+        active=True,
+    )
+
+    client = TestClient(app)
+
+    response = client.patch(
+        f"/users/{other_user_id}/consents",
+        json={
+            "consents": [
+                {
+                    "clause_id": str(uuid4()),
+                    "accepted": True,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "cannot_manage_other_user_consents"

--- a/apps/frontend/src/api/profile.js
+++ b/apps/frontend/src/api/profile.js
@@ -12,3 +12,15 @@ export function updateMyProfile(payload) {
 export function exportMyData() {
   return apiClient.get("/auth/me/export", getAuthOptions());
 }
+
+export function getMyConsentPreferences(userId) {
+  return apiClient.get(`/users/${userId}/consents`, getAuthOptions());
+}
+
+export function updateMyConsentPreferences(userId, consents) {
+  return apiClient.patch(
+    `/users/${userId}/consents`,
+    { consents },
+    getAuthOptions(),
+  );
+}

--- a/apps/frontend/src/pages/dashboard/consent-management/ConsentManagementPage.jsx
+++ b/apps/frontend/src/pages/dashboard/consent-management/ConsentManagementPage.jsx
@@ -1,0 +1,392 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  RotateCcw,
+  ShieldCheck,
+  ShieldOff,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  getMyConsentPreferences,
+  getMyProfile,
+  updateMyConsentPreferences,
+} from "@/api/profile";
+import { clearClientSession } from "@/api/consent";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+function formatPolicyType(policyType) {
+  if (policyType === "TERMS_OF_USE") return "Termos de Uso";
+  if (policyType === "PRIVACY_POLICY") return "Política de Privacidade";
+  return String(policyType || "Documento").replaceAll("_", " ");
+}
+
+function formatDateTime(value) {
+  if (!value) return "Sem registro";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function getStatusLabel(consent) {
+  if (consent.accepted) return "Accepted";
+  if (consent.current_status === "PENDING") return "Pending";
+  return "Revoked";
+}
+
+function ConfirmationModal({
+  pendingChange,
+  confirmationText,
+  saving,
+  onCancel,
+  onConfirm,
+  onConfirmationTextChange,
+}) {
+  if (!pendingChange) return null;
+
+  const isMandatoryRevocation =
+    pendingChange.mandatory && pendingChange.nextAccepted === false;
+
+  const canConfirm = !isMandatoryRevocation || confirmationText === "DELETE";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 backdrop-blur-sm">
+      <div className="w-full max-w-lg rounded-xl border border-border bg-card p-6 shadow-lg">
+        <div className="flex items-start gap-3">
+          <div
+            className={
+              isMandatoryRevocation
+                ? "rounded-full bg-destructive/10 p-2 text-destructive"
+                : "rounded-full bg-primary/10 p-2 text-primary"
+            }
+          >
+            {isMandatoryRevocation ? (
+              <AlertTriangle className="h-5 w-5" />
+            ) : (
+              <ShieldCheck className="h-5 w-5" />
+            )}
+          </div>
+
+          <div>
+            <h3 className="text-lg font-semibold text-foreground">
+              {isMandatoryRevocation
+                ? "Mandatory consent revocation"
+                : "Confirm consent update"}
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {pendingChange.clause_title}
+            </p>
+          </div>
+        </div>
+
+        {isMandatoryRevocation ? (
+          <div className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-foreground">
+            <p className="font-semibold text-destructive">
+              This action will permanently delete/anonymize your account.
+            </p>
+            <ul className="mt-3 list-disc space-y-1 pl-5 text-muted-foreground">
+              <li>Your account and personal data will be permanently removed or anonymized.</li>
+              <li>This action cannot be undone.</li>
+              <li>Your active session access will be removed immediately.</li>
+            </ul>
+
+            <label className="mt-4 block text-xs font-medium text-foreground">
+              Type DELETE to confirm
+            </label>
+            <Input
+              className="mt-2"
+              value={confirmationText}
+              onChange={(event) => onConfirmationTextChange(event.target.value)}
+              placeholder="DELETE"
+              disabled={saving}
+            />
+          </div>
+        ) : (
+          <p className="mt-5 text-sm leading-6 text-muted-foreground">
+            This will register a new append-only consent event as{" "}
+            <strong className="text-foreground">
+              {pendingChange.nextAccepted ? "accepted" : "revoked"}
+            </strong>
+            . Previous consent records will not be changed.
+          </p>
+        )}
+
+        <div className="mt-6 flex justify-end gap-3">
+          <Button type="button" variant="outline" onClick={onCancel} disabled={saving}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant={isMandatoryRevocation ? "destructive" : "default"}
+            onClick={onConfirm}
+            disabled={saving || !canConfirm}
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            {isMandatoryRevocation ? "Confirm deletion" : "Confirm update"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ConsentManagementPage() {
+  const navigate = useNavigate();
+
+  const [profile, setProfile] = useState(null);
+  const [consents, setConsents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const [loadError, setLoadError] = useState("");
+  const [pendingChange, setPendingChange] = useState(null);
+  const [confirmationText, setConfirmationText] = useState("");
+
+  async function loadData() {
+    setLoading(true);
+    setLoadError("");
+
+    try {
+      const profileData = await getMyProfile();
+      const consentData = await getMyConsentPreferences(profileData.user_uuid);
+
+      setProfile(profileData);
+      setConsents(consentData.consents || []);
+    } catch {
+      setLoadError("Could not load your consent preferences.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const groupedConsents = useMemo(() => {
+    return consents.reduce((groups, consent) => {
+      const key = `${consent.policy_type}-${consent.policy_version}`;
+      if (!groups[key]) {
+        groups[key] = {
+          policy_type: consent.policy_type,
+          policy_version: consent.policy_version,
+          items: [],
+        };
+      }
+      groups[key].items.push(consent);
+      return groups;
+    }, {});
+  }, [consents]);
+
+  function requestConsentChange(consent, nextAccepted) {
+    setPendingChange({
+      ...consent,
+      nextAccepted,
+    });
+    setConfirmationText("");
+  }
+
+  function cancelPendingChange() {
+    setPendingChange(null);
+    setConfirmationText("");
+  }
+
+  async function confirmPendingChange() {
+    if (!pendingChange || !profile?.user_uuid) return;
+
+    setSaving(true);
+
+    try {
+      const response = await updateMyConsentPreferences(profile.user_uuid, [
+        {
+          clause_id: pendingChange.clause_id,
+          accepted: pendingChange.nextAccepted,
+        },
+      ]);
+
+      if (response.account_deleted) {
+        clearClientSession();
+        navigate("/goodbye", { replace: true });
+        return;
+      }
+
+      setConsents(response.consents || []);
+      setPendingChange(null);
+      setConfirmationText("");
+      toast.success("Consent preference updated.");
+    } catch {
+      toast.error("Could not update consent preference.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[360px] items-center justify-center">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span className="text-sm">Loading consent preferences...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground">
+          Consent Management
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Review, accept or revoke individual consent clauses at any time.
+        </p>
+      </div>
+
+      {loadError ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {loadError}
+        </div>
+      ) : null}
+
+      <Card className="rounded-lg">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            Current consent preferences
+          </CardTitle>
+          <CardDescription>
+            Every change creates a new append-only consent log entry.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {Object.values(groupedConsents).length === 0 ? (
+            <div className="rounded-lg border border-border bg-muted/20 px-4 py-6 text-center text-sm text-muted-foreground">
+              No current consent clauses were found.
+            </div>
+          ) : (
+            Object.values(groupedConsents).map((group) => (
+              <section key={`${group.policy_type}-${group.policy_version}`} className="space-y-3">
+                <div>
+                  <h3 className="text-base font-semibold text-foreground">
+                    {formatPolicyType(group.policy_type)}
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    Version {group.policy_version}
+                  </p>
+                </div>
+
+                <div className="space-y-3">
+                  {group.items.map((consent) => {
+                    const statusLabel = getStatusLabel(consent);
+
+                    return (
+                      <div
+                        key={consent.clause_id}
+                        className="rounded-lg border border-border bg-background p-4"
+                      >
+                        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h4 className="font-medium text-foreground">
+                                {consent.clause_title}
+                              </h4>
+                              <span
+                                className={
+                                  consent.mandatory
+                                    ? "rounded-full bg-destructive/10 px-2 py-1 text-xs font-medium text-destructive"
+                                    : "rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary"
+                                }
+                              >
+                                {consent.mandatory ? "Mandatory" : "Optional"}
+                              </span>
+                              <span
+                                className={
+                                  consent.accepted
+                                    ? "inline-flex items-center gap-1 rounded-full bg-chart-1/10 px-2 py-1 text-xs font-medium text-chart-1"
+                                    : "inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1 text-xs font-medium text-muted-foreground"
+                                }
+                              >
+                                {consent.accepted ? (
+                                  <CheckCircle2 className="h-3 w-3" />
+                                ) : (
+                                  <ShieldOff className="h-3 w-3" />
+                                )}
+                                {statusLabel}
+                              </span>
+                            </div>
+
+                            {consent.clause_description ? (
+                              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                                {consent.clause_description}
+                              </p>
+                            ) : null}
+
+                            <p className="mt-3 text-xs text-muted-foreground">
+                              Last action: {formatDateTime(consent.last_action_at)}
+                            </p>
+                          </div>
+
+                          <div className="flex shrink-0 gap-2">
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant={consent.accepted ? "outline" : "default"}
+                              disabled={saving || consent.accepted}
+                              onClick={() => requestConsentChange(consent, true)}
+                            >
+                              Accept
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant={consent.accepted ? "destructive" : "outline"}
+                              disabled={saving || !consent.accepted}
+                              onClick={() => requestConsentChange(consent, false)}
+                            >
+                              Revoke
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      <Button
+        type="button"
+        variant="outline"
+        className="w-fit"
+        onClick={loadData}
+        disabled={loading || saving}
+      >
+        <RotateCcw className="h-4 w-4" />
+        Reload preferences
+      </Button>
+
+      <ConfirmationModal
+        pendingChange={pendingChange}
+        confirmationText={confirmationText}
+        saving={saving}
+        onCancel={cancelPendingChange}
+        onConfirm={confirmPendingChange}
+        onConfirmationTextChange={setConfirmationText}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/dashboard/profile/ProfilePage.jsx
+++ b/apps/frontend/src/pages/dashboard/profile/ProfilePage.jsx
@@ -1,5 +1,6 @@
+import { Link } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
-import { AlertCircle, CheckCircle2, Download, Loader2, Mail, Save, Shield, Trash2, User } from "lucide-react";
+import { AlertCircle, CheckCircle2, Download, Loader2, Mail, Save, Shield, ShieldCheck, Trash2, User } from "lucide-react";
 import { toast } from "sonner";
 
 import { exportMyData, getMyProfile, updateMyProfile } from "@/api/profile";
@@ -172,87 +173,71 @@ export default function ProfilePage() {
       <div>
         <h2 className="text-2xl font-semibold text-foreground">Meu Perfil</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Consulte e atualize somente as informacoes vinculadas a sua propria conta.
+          Consulte e atualize suas informacoes pessoais.
         </p>
       </div>
 
-      {error && (
-        <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+      {error ? (
+        <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
           <span>{error}</span>
         </div>
-      )}
+      ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <Card className="rounded-lg">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <User className="h-4 w-4 text-primary" />
-              Dados cadastrais
+            <CardTitle className="flex items-center gap-2">
+              <User className="h-5 w-5 text-primary" />
+              Dados pessoais
             </CardTitle>
             <CardDescription>
-              Nome e email sao dados pessoais da sua conta e nao alteram seu cargo no sistema.
+              Essas informacoes sao utilizadas para identificacao na plataforma.
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
-              <div className="grid gap-2">
-                <label className="text-sm font-medium text-foreground" htmlFor="profile-username">
-                  Nome
+            <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground" htmlFor="username">
+                  Nome de usuario
                 </label>
-                <div className="relative">
-                  <User className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    id="profile-username"
-                    name="username"
-                    value={form.username}
-                    onChange={handleChange}
-                    className="pl-9"
-                    autoComplete="name"
-                    disabled={isSaving}
-                  />
-                </div>
+                <Input
+                  id="username"
+                  name="username"
+                  value={form.username}
+                  onChange={handleChange}
+                  placeholder="Seu nome"
+                  disabled={isSaving}
+                />
               </div>
 
-              <div className="grid gap-2">
-                <label className="text-sm font-medium text-foreground" htmlFor="profile-email">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground" htmlFor="email">
                   Email
                 </label>
                 <div className="relative">
                   <Mail className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
-                    id="profile-email"
+                    id="email"
                     name="email"
                     type="email"
                     value={form.email}
                     onChange={handleChange}
+                    placeholder="voce@email.com"
                     className="pl-9"
-                    autoComplete="email"
                     disabled={isSaving}
                   />
                 </div>
               </div>
 
-              <div className="grid gap-2">
-                <label className="text-sm font-medium text-foreground" htmlFor="profile-role">
-                  Cargo
-                </label>
-                <div className="relative">
-                  <Shield className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    id="profile-role"
-                    value={profile?.profile_name || ""}
-                    className="pl-9"
-                    disabled
-                    readOnly
-                  />
-                </div>
-              </div>
-
               <div className="flex justify-end">
-                <Button type="submit" disabled={isSaving || !hasChanges}>
+                <Button
+                  type="submit"
+                  disabled={!hasChanges || isSaving}
+                  className="min-w-36"
+                >
                   {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                  Salvar alteracoes
+                  {isSaving ? "Salvando..." : "Salvar alteracoes"}
                 </Button>
               </div>
             </form>
@@ -290,6 +275,26 @@ export default function ProfilePage() {
                 <p className="text-xs text-muted-foreground">Ultima atualizacao</p>
                 <p className="mt-1 font-medium text-foreground">{formatDateTime(profile?.updated_at)}</p>
               </div>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <ShieldCheck className="h-4 w-4 text-primary" />
+                Consentimentos
+              </CardTitle>
+              <CardDescription>
+                Revise ou altere seus consentimentos individualmente a qualquer momento.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild variant="outline" className="w-full border-border text-foreground hover:bg-muted">
+                <Link to="/dashboard/consentimentos">
+                  <ShieldCheck className="h-4 w-4" />
+                  Gerenciar consentimentos
+                </Link>
+              </Button>
             </CardContent>
           </Card>
 

--- a/apps/frontend/src/pages/login/GoodbyePage.jsx
+++ b/apps/frontend/src/pages/login/GoodbyePage.jsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router-dom";
+import { ShieldAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export default function GoodbyePage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="max-w-lg rounded-xl border border-border bg-card p-8 text-center shadow-sm">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+          <ShieldAlert className="h-6 w-6 text-destructive" />
+        </div>
+
+        <h1 className="text-2xl font-semibold text-foreground">
+          Account access ended
+        </h1>
+
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          Your mandatory consent was revoked. Your account was anonymized and
+          all active sessions were invalidated according to the LGPD consent
+          management flow.
+        </p>
+
+        <Button asChild className="mt-6">
+          <Link to="/login">Return to login</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/routes/index.jsx
+++ b/apps/frontend/src/routes/index.jsx
@@ -4,6 +4,7 @@ import ConsentPage from "../pages/login/ConsentPage";
 import ForgotPasswordPage from "../pages/login/ForgotPasswordPage";
 import ResetPasswordPage from "../pages/login/ResetPasswordPage";
 import PrimeiroAcessoPage from "../pages/login/PrimeiroAcessoPage";
+import GoodbyePage from "../pages/login/GoodbyePage";
 import DashboardLayout from "../layouts/DashboardLayout";
 import ProtectedRoute, { TokenRequiredRoute, RoleRequiredRoute } from "@/components/auth/ProtectedRoute";
 import IndicadoresPage from "../pages/dashboard/indicadores-page/IndicadoresPage";
@@ -12,6 +13,7 @@ import UsuariosPage from "../pages/dashboard/user-management/UsuariosPage";
 import TermsPage from "../pages/dashboard/terms-management/TermsPage";
 import { HeatmapFilters } from "../pages/dashboard/heatmap/HeatmapFilters";
 import ProfilePage from "../pages/dashboard/profile/ProfilePage";
+import ConsentManagementPage from "../pages/dashboard/consent-management/ConsentManagementPage";
 import IncidentNotificationPage from "../pages/dashboard/incident-notification/IncidentNotificationPage";
 
 function NotFoundPage() {
@@ -28,6 +30,7 @@ export function AppRoutes() {
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route path="/consent" element={<TokenRequiredRoute><ConsentPage /></TokenRequiredRoute>} />
+        <Route path="/goodbye" element={<GoodbyePage />} />
         <Route path="/first-access" element={<PrimeiroAcessoPage />} />
         <Route path="/primeiro-acesso" element={<Navigate to="/first-access" replace />} />
         <Route path="/" element={<Navigate to="/dashboard/indicadores" replace />} />
@@ -37,11 +40,12 @@ export function AppRoutes() {
             <Route path="indicadores" element={<IndicadoresPage />} />
             <Route path="estrutura-redes" element={<EstruturaRedesPage />} />
             <Route path="perfil" element={<ProfilePage />} />
-            <Route path="usuarios" element={<RoleRequiredRoute allowedProfiles={["ADMIN","MANAGER"]}><UsuariosPage /></RoleRequiredRoute>} />
+            <Route path="consentimentos" element={<ConsentManagementPage />} />
+            <Route path="usuarios" element={<RoleRequiredRoute allowedProfiles={["ADMIN", "MANAGER"]}><UsuariosPage /></RoleRequiredRoute>} />
             <Route path="termos" element={<RoleRequiredRoute allowedProfiles={["ADMIN"]}><TermsPage /></RoleRequiredRoute>} />
             <Route path="incident-notification" element={<RoleRequiredRoute allowedProfiles={["ADMIN"]}><IncidentNotificationPage /></RoleRequiredRoute>} />
+            <Route path="heatmap" element={<HeatmapFilters />} />
             <Route path="*" element={<NotFoundPage />} />
-            <Route path="heatmap" element={<HeatmapFilters/>} />
           </Route>
         </Route>
       </Routes>


### PR DESCRIPTION

#509

## 🔗 Related Issue

> Auto-detected from branch. Confirm or edit if needed.
> Branch: `feature/bugfix/509-consent-management-screen-accept-or-revoke-terms-at-any-time` → Issue: #509

Closes #509

---

## 🏷️ Change Type

- [X] Bug fix
- [X] Feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs

**Breaking change:** <!-- If checked, describe what breaks and the migration steps -->

---

## 📝 What was done?

> Explain what was implemented and why. Be specific about the approach taken.

- Added authenticated consent management endpoints for users to review and update their own consent preferences after onboarding.
- Added append-only consent updates, recording every acceptance or revocation as a new `TB_CONSENT_LOG` event.
- Implemented mandatory consent revocation flow with account anonymization and synchronous session invalidation.
- Added frontend consent management screen accessible from the authenticated profile area.
- Added confirmation modal for consent changes and destructive confirmation flow for mandatory consent revocation.
- Added goodbye page redirect after mandatory consent revocation.
- Added automated backend tests for consent update behavior and access protection.

---

## 🧪 How to test locally

> Step-by-step instructions for the reviewer to validate this PR.

### 1. Start the environment

```bash

docker compose --profile frontend up --build
```

Frontend:

```text
http://localhost:5173
```

Backend Swagger:

```text
http://localhost:8000/docs
```

---

### 2. Run backend automated tests

```bash
docker compose --profile frontend run --rm backend pytest tests/test_user_consent_management.py -q
```

Expected result:

```text
7 passed
```

---

### 3. Run frontend build

```bash
docker compose --profile frontend run --rm frontend npm run build
```

Expected result:

```text
build completed successfully
```

---

### 4. Manual frontend validation

1. Login normally.
2. If redirected to the initial consent screen, accept the mandatory clauses.
3. Open:

```text
/dashboard/perfil
```

4. Click **Gerenciar consentimentos**.
5. Confirm that the app opens:

```text
/dashboard/consentimentos
```

6. Confirm that the consent screen lists:

```text
- clause title
- clause description
- policy type/version
- mandatory or optional label
- current status
- last action date
- accept/revoke buttons
```

---

### 5. Optional consent test

1. Revoke an optional consent.
2. Confirm the normal modal.
3. Expected result:

```text
- user remains logged in
- consent status changes to revoked
- last action date updates
- no redirect happens
```

4. Accept the same optional consent again.
5. Expected result:

```text
- user remains logged in
- consent status changes to accepted
- last action date updates
```

---

### 6. Cancel modal test

1. Click `Accept` or `Revoke` on any clause.
2. When the modal opens, click `Cancel`.

Expected result:

```text
- modal closes
- no consent change is applied
- user remains logged in
```

---

### 7. Mandatory consent revocation test

1. Click `Revoke` on a mandatory clause.
2. Confirm that a destructive warning modal appears.
3. Confirm that the modal explains:

```text
- account and personal data will be deleted/anonymized
- the action cannot be undone
- session access will be removed immediately
```

4. Try to confirm without typing `DELETE`.

Expected result:

```text
confirmation button remains disabled
```

5. Type:

```text
DELETE
```

6. Confirm deletion.

Expected result:

```text
- backend returns account_deleted = true
- frontend clears session
- user is redirected to /goodbye
```

7. Try accessing:

```text
/dashboard/perfil
```

Expected result:

```text
user is redirected to login
```

---

### 8. Swagger/API validation

Authenticate in Swagger and call:

```http
PATCH /users/{uuid}/consents
```

With another user’s UUID.

Expected result:

```http
403 Forbidden
```

Expected response:

```json
{
  "detail": "cannot_manage_other_user_consents"
}
```


---

## 🚀 Deploy Notes

> Migrations, env vars, or infra changes required for this PR.

- [X] No special deploy steps needed
- [ ] Database migration required
- [ ] New environment variable(s) required
- [ ] Infrastructure change required

---

## ⚠️ Risks and Potential Impact

> Describe possible side effects or risks of this change.

- Medium risk: this change affects consent management, user sessions and account anonymization.
- Mandatory consent revocation is destructive and intentionally invalidates all active sessions.
- Optional consent revocation should not affect user access.
- The endpoint must remain self-only; users cannot update another user’s consent records.
- The backend must insert new consent events only; existing TB_CONSENT_LOG rows must never be updated.
- The frontend must only redirect to /goodbye when the backend returns account_deleted: true.

---

## 📸 Evidence

> Add screenshots, logs or relevant outputs.

<img width="861" height="264" alt="image" src="https://github.com/user-attachments/assets/8120d261-1ea0-4b69-a9fe-ac723bb75e44" />

---

## ✅ Definition of Done

- [X] All acceptance criteria from the issue are met
- [X] Code reviewed before submitting

---

## ✅ Final Checklist

- [ ] My code follows the project style guide
- [ ] I reviewed my own code before submitting
- [ ] I added comments for complex or non-obvious code
- [ ] Documentation updated if needed
- [ ] My changes do not generate new warnings
- [ ] New and existing tests pass with my changes

<details>
<summary>🐛 Traceability</summary>

**Issue:** #509
**Type:** `bugfix`
**Branch:** `bugfix/509-consent-management-screen-accept-or-revoke-terms-at-any-time`

</details>