### PR TITLE
Feature/478 access control logout via keycloak and documentation updates

### DIFF
--- a/apps/backend/src/config/logger.py
+++ b/apps/backend/src/config/logger.py
@@ -46,16 +46,3 @@ def configure_logging() -> None:
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
     )
-
-structlog.configure(
-    processors=[
-        structlog.contextvars.merge_contextvars,  # novo — injeta request_id, method, path, user_id
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.JSONRenderer(),
-    ],
-    wrapper_class=structlog.stdlib.BoundLogger,
-    context_class=dict,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-)

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -32,7 +32,6 @@ structlog processors
   - JSONRenderer       → serializes to a single JSON line
         ↓
 stdlib root logger
-  - StreamHandler      → writes to container stdout
   - TimedRotatingFileHandler → writes to logs/app.log
         ↓
 LoggingMiddleware
@@ -47,7 +46,7 @@ LoggingMiddleware
 | Path | Description |
 |---|---|
 | `logs/app.log` | Current active log file |
-| `logs/app.log.YYYY-MM-DD_HH-MM-SS.gz` | Rotated and compressed files |
+| `logs/app.log.YYYY-MM-DD.gz` | Rotated and compressed files |
 
 The `logs/` directory is mapped as a Docker volume (`./logs:/app/logs`) and persists across container restarts.
 
@@ -110,11 +109,7 @@ The following fields must **never** appear in any log entry:
 
 Use only UUIDs and operational metadata (counts, status codes, durations, flags).
 
-The script `scripts/validate_log_privacy.py` can be used to audit the log file:
-
-```bash
-docker compose --profile backend exec backend python scripts/validate_log_privacy.py logs/app.log
-```
+To audit the log file manually, search for prohibited field names using `grep` or any JSON log viewer against `logs/app.log`.
 
 ---
 
@@ -125,21 +120,27 @@ Request lifecycle with a successful user creation:
 ```json
 {"event": "request_started", "path": "/users/", "method": "POST", "user_id": null, "request_id": "9da79a28-913f-4928-9a95-e263110572f3", "level": "info", "logger": "src.config.logging_middleware", "timestamp": "2026-04-27T01:09:08.223352Z"}
 {"event": "user.created", "user_id": "1933c4ff-5b63-4189-b1b7-293a11cfc2a0", "profile_id": "dbdeb4a7-ec76-4643-931a-78616c1e3f68", "path": "/users/", "method": "POST", "request_id": "9da79a28-913f-4928-9a95-e263110572f3", "level": "info", "logger": "src.api.routes.users", "timestamp": "2026-04-27T01:09:08.447733Z"}
-{"event": "request_finished", "status_code": 201, "duration_ms": 225.01, "path": "/users/", "method": "POST", "request_id": "9da79a28-913f-4928-9a95-e263110572f3", "level": "info", "logger": "src.config.logging_middleware", "timestamp": "2026-04-27T01:09:08.448862Z"}
+{"event": "request_finished", "status_code": 201, "duration_ms": 225.01, "path": "/users/", "method": "POST", "user_id": null, "request_id": "9da79a28-913f-4928-9a95-e263110572f3", "level": "info", "logger": "src.config.logging_middleware", "timestamp": "2026-04-27T01:09:08.448862Z"}
 ```
 
-Validation error example:
+Validation error example (sensitive fields are filtered from `errors` before logging):
 
 ```json
-{"event": "validation_error", "path": "/users/", "errors": [{"type": "value_error", "loc": ["body", "password"], "msg": "A senha deve conter pelo menos uma letra maiúscula."}], "request_id": "bdaa2f89-5bac-4701-b764-3039ee881040", "level": "warning", "logger": "src.config.exception_handlers", "timestamp": "2026-04-27T01:37:04.313103Z"}
+{"event": "validation_error", "path": "/users/", "error_count": 1, "errors": [{"type": "value_error", "loc": ["body", "password"], "msg": "A senha deve conter pelo menos uma letra maiúscula."}], "request_id": "bdaa2f89-5bac-4701-b764-3039ee881040", "level": "warning", "logger": "src.config.exception_handlers", "timestamp": "2026-04-27T01:37:04.313103Z"}
 ```
 
 Unhandled exception example:
 
 ```json
-{"event": "unhandled_exception", "exception_type": "RuntimeError", "message": "unexpected error", "exc_info": true, "request_id": "61303840-b9bc-40f5-8240-97102a36e5e1", "level": "error", "logger": "src.config.exception_handlers", "timestamp": "2026-04-27T01:41:22.284878Z"}
+{"event": "unhandled_exception", "error_code": "internal_server_error", "category": "internal", "status_code": 500, "exception_type": "RuntimeError", "message": "unexpected error", "exc_info": true, "request_id": "61303840-b9bc-40f5-8240-97102a36e5e1", "level": "error", "logger": "src.config.exception_handlers", "timestamp": "2026-04-27T01:41:22.284878Z"}
+```
+
+Request finished with server error (status ≥ 500 is logged at `error` level):
+
+```json
+{"event": "request_finished", "status_code": 500, "duration_ms": 12.5, "path": "/users/", "method": "POST", "user_id": "1933c4ff-5b63-4189-b1b7-293a11cfc2a0", "request_id": "61303840-b9bc-40f5-8240-97102a36e5e1", "level": "error", "logger": "src.config.logging_middleware", "timestamp": "2026-04-27T01:41:22.295000Z"}
 ```
 
 ---
 
-*Last updated: 04/26/2026*
+*Last updated: 05/31/2026*


### PR DESCRIPTION
## 🔗 Related Issue

Closes #478477

---

## 🏷️ Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs

---

## 📝 What was done?

- Removed a duplicate top-level `structlog.configure()` call in `logger.py` that ran unconditionally on import and overrode the configuration already applied inside `configure_logging()`.
- Updated `LOGGING.md` to match the current implementation: removed `StreamHandler` from the pipeline diagram, corrected the rotated file name pattern to `YYYY-MM-DD.gz`, replaced the deleted `validate_log_privacy.py` script reference with a manual `grep` instruction, and updated log examples to reflect current fields (`user_id` in `request_finished`, `error_count` in `validation_error`, `error_code`/`category`/`status_code` in `unhandled_exception`, and the 500-level `request_finished` entry).

---

## 🧪 How to test locally

```bash
# 1. Start the environment
docker compose up

# 2. Make any authenticated request and inspect the output
docker compose logs backend | grep '"event"'
# Confirm each line is valid JSON and that no duplicate structlog
# configuration warning appears on startup
```

---

## 🚀 Deploy Notes

> Migrations, env vars, or infra changes required for this PR.

- [x] No special deploy steps needed
- [ ] Database migration required
- [ ] New environment variable(s) required
- [ ] Infrastructure change required

---

## ⚠️ Risks and Potential Impact

- None. The duplicate structlog.configure was silently overriding settings; removing it restores the intended behavior with no API or output format change.

---

## 📸 Evidence

<img width="1825" height="1593" alt="image" src="https://github.com/user-attachments/assets/17563dc2-b157-4ebd-825c-725540634e9e" />

---

## ✅ Definition of Done

- [x] All acceptance criteria from the issue are met
- [x] Code reviewed before submitting

---

## ✅ Final Checklist

- [x] My code follows the project style guide
- [x] I reviewed my own code before submitting
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated if needed
- [x] My changes do not generate new warnings
- [x] New and existing tests pass with my changes

<details>
<summary>✨ Traceability</summary>

**Issue:** #478
**Type:** `feature`
**Branch:** `feature/478-access-control-logout-via-keycloak-and-documentation-updates`

</details>